### PR TITLE
S3 lock backend

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,6 +218,67 @@ jobs:
           docker logs minio-server
           docker stop minio-server
 
+  conformance-s3-lock:
+    runs-on: ubuntu-latest
+    needs: build-conformance
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: conformance-tools
+
+      - name: Load container image
+        run: |
+          docker load -i conformance-image.tar
+          chmod +x conformance.test zb
+
+      - name: Run conformance test & zot benchmark (s3 backend with s3 lock, no cache)
+        run: |
+          mkdir -p ./conformance/minio-data/registry
+          docker run --rm -d \
+            -v ./conformance/minio-data:/data \
+            -e MINIO_ROOT_USER=root \
+            -e MINIO_ROOT_PASSWORD=roottoor \
+            -e MINIO_VOLUMES=/data \
+            --network host \
+            --name minio-server \
+            quay.io/minio/minio \
+            minio server /data
+
+          while ! nc -z localhost 9000; do
+            echo "Waiting for minio to start..."
+            sleep 1;
+          done
+
+          docker run --rm -d \
+            -v ./conformance/config-s3-lock.toml:/config.toml \
+            --network host \
+            --name conformance-s3-lock-backend \
+            ${CONFORMANCE_IMAGE_NAME} \
+            server
+
+          for i in {1..10}; do
+            if nc -z -w 3 127.0.0.1 8000; then
+              break
+            fi
+            sleep 1
+          done
+          if [ $i -eq 10 ]; then
+            echo "angos did not start within 10 seconds"
+            exit 1
+          fi
+
+          source ./conformance/conformance-variables
+          ./conformance.test
+
+          time ./zb -c 5 -r conformance -n 100 http://localhost:8000
+          docker logs conformance-s3-lock-backend
+          docker stop conformance-s3-lock-backend
+          docker logs minio-server
+          docker stop minio-server
+
   build-binary:
     strategy:
       fail-fast: false
@@ -378,6 +439,7 @@ jobs:
       - rust-test
       - conformance-fs
       - conformance-s3
+      - conformance-s3-lock
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -154,8 +154,12 @@ jobs:
           ./conformance.test
 
           time ./zb -c 5 -r conformance -n 100 http://localhost:8000
-          docker logs conformance-fs-backend
-          docker stop conformance-fs-backend
+
+      - name: Dump registry logs (filesystem backend)
+        if: always()
+        run: |
+          docker logs conformance-fs-backend || true
+          docker stop conformance-fs-backend || true
 
   conformance-s3:
     runs-on: ubuntu-latest
@@ -213,10 +217,14 @@ jobs:
           ./conformance.test
 
           time ./zb -c 5 -r conformance -n 100 http://localhost:8000
-          docker logs conformance-s3-backend
-          docker stop conformance-s3-backend
-          docker logs minio-server
-          docker stop minio-server
+
+      - name: Dump registry logs (s3 backend)
+        if: always()
+        run: |
+          docker logs conformance-s3-backend || true
+          docker stop conformance-s3-backend || true
+          docker logs minio-server || true
+          docker stop minio-server || true
 
   conformance-s3-lock:
     runs-on: ubuntu-latest
@@ -274,10 +282,14 @@ jobs:
           ./conformance.test
 
           time ./zb -c 5 -r conformance -n 100 http://localhost:8000
-          docker logs conformance-s3-lock-backend
-          docker stop conformance-s3-lock-backend
-          docker logs minio-server
-          docker stop minio-server
+
+      - name: Dump registry logs (s3 backend with s3 lock)
+        if: always()
+        run: |
+          docker logs conformance-s3-lock-backend || true
+          docker stop conformance-s3-lock-backend || true
+          docker logs minio-server || true
+          docker stop minio-server || true
 
   build-binary:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,15 +56,15 @@ dependencies = [
  "prometheus",
  "redis",
  "regex",
- "reqwest",
+ "reqwest 0.13.2",
  "rpassword",
  "rust-embed",
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2 0.11.0-rc.3",
+ "sha2 0.11.0-rc.5",
  "tempfile",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -98,15 +98,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
 ]
@@ -119,20 +119,19 @@ checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "argh"
-version = "0.1.13"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ff18325c8a36b82f992e533ece1ec9f9a9db446bd1c14d4f936bac88fcd240"
+checksum = "42a66b74feaa2a7eddc2a74d273f151b545742ef375581c5a566607df992565e"
 dependencies = [
  "argh_derive",
  "argh_shared",
- "rust-fuzzy-search",
 ]
 
 [[package]]
 name = "argh_derive"
-version = "0.1.13"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b2b83a50d329d5d8ccc620f5c7064028828538bdf5646acd60dc1f767803"
+checksum = "0ce8f59ed4ec07742760cf3593727c8caff28ef4537eeb33be25e5fb454850d1"
 dependencies = [
  "argh_shared",
  "proc-macro2",
@@ -142,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "argh_shared"
-version = "0.1.13"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a464143cc82dedcdc3928737445362466b7674b5db4e2eb8e869846d6d84f4f6"
+checksum = "284b476f7c2b6af9aa49f059466ebfa725b0f53c33d271a691e613e9187bf507"
 dependencies = [
  "serde",
 ]
@@ -173,7 +172,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -235,9 +234,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.11"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -247,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -258,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -270,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.17"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81b5b2898f6798ad58f484856768bca817e3cd9de0974c24ae0f1113fe88f1b"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -284,9 +283,12 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "fastrand",
  "http 0.2.12",
+ "http 1.4.0",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -295,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.119.0"
+version = "1.125.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+checksum = "223f5c95650d9557925a91f4c2db3def189e8f659452134a29e5cd2d37d708ed"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -307,6 +309,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -318,7 +321,7 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "http 1.4.0",
- "http-body 0.4.6",
+ "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
@@ -329,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.7"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -357,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.7"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee19095c7c4dda59f1697d028ce704c24b2d33c6718790c7f1d5a3015b4107c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -368,17 +371,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.12"
+version = "0.64.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+checksum = "6750f3dd509b0694a4377f0293ed2f9630d710b1cebe281fa8bac8f099f88bc6"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
  "hex",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "md-5",
  "pin-project-lite",
  "sha1",
@@ -388,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.14"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc12f8b310e38cad85cf3bef45ad236f470717393c613266ce0a89512286b650"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -399,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.6"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -410,9 +414,9 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 0.2.12",
  "http 1.4.0",
- "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -421,15 +425,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.5"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.12",
+ "h2 0.4.13",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -440,7 +444,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -451,27 +455,27 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.9"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f616c3f2260612fe44cede278bafa18e73e6479c4e393e2c4518cf2a9a228a"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.5"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a392db6c583ea4a912538afb86b7be7c5d8887d91604f50eb55c262ee1b4a5f5"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -485,6 +489,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -493,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.9.3"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0d43d899f9e508300e587bf582ba54c27a452dd0a9ea294690669138ae14a2"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -510,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905cb13a9895626d49cf2ced759b062d913834c7482c38e49557eac4e6193f01"
+checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -536,18 +541,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.13"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.11"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -581,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "better_any"
@@ -614,9 +619,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake2"
@@ -638,18 +643,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -659,9 +664,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -684,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -720,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,9 +744,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -776,9 +787,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -807,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -822,15 +833,14 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
  "digest 0.10.7",
- "rand",
- "regex",
  "rustversion",
+ "spin",
 ]
 
 [[package]]
@@ -876,18 +886,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211f05e03c7d03754740fd9e585de910a095d6b99f8bcfffdef8319fa02a8331"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deadpool"
@@ -933,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -953,13 +963,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
+checksum = "285743a676ccb6b3e116bc14cc69319b957867930ae9c4822f8e0f54509d7243"
 dependencies = [
- "block-buffer 0.11.0",
- "const-oid 0.10.1",
- "crypto-common 0.2.0",
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1051,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -1066,6 +1076,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1093,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1108,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1118,15 +1134,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1135,15 +1151,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1152,21 +1168,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1176,7 +1192,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1192,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1212,9 +1227,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1249,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1272,9 +1300,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1282,6 +1308,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1379,9 +1416,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b229d73f5803b562cc26e4da0396c8610a4ee209f4fac8fa4f8d709166dc45"
+checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
 dependencies = [
  "typenum",
 ]
@@ -1420,7 +1457,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1457,13 +1494,12 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1481,14 +1517,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -1497,7 +1532,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1505,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1609,6 +1644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,21 +1672,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -1661,15 +1704,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1686,9 +1729,31 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -1702,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1712,13 +1777,13 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.2.0"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "aws-lc-rs",
  "base64",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
  "serde",
@@ -1754,16 +1819,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1788,11 +1859,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1822,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1885,7 +1956,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1899,9 +1970,12 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1924,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -1973,9 +2047,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
@@ -1987,7 +2061,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -2001,7 +2075,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -2016,8 +2090,8 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
- "thiserror 2.0.17",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tracing",
@@ -2048,7 +2122,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -2128,18 +2202,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2148,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2193,10 +2267,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.103"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2213,14 +2297,14 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2228,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2271,9 +2355,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.35",
- "socket2 0.6.1",
- "thiserror 2.0.17",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2281,20 +2365,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2309,16 +2394,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2330,13 +2415,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2346,7 +2437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2355,23 +2446,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "redis"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfe20977fe93830c0e9817a16fbf1ed1cfd8d4bba366087a1841d2c6033c251"
+checksum = "b36964393906eb775b89b25b05b7b95685b8dd14062f1663a31ff93e75c452e5"
 dependencies = [
  "arcstr",
  "bytes",
@@ -2384,7 +2475,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio",
  "tokio-util",
  "url",
@@ -2397,14 +2488,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2414,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2425,15 +2516,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2450,6 +2541,39 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -2457,11 +2581,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -2474,7 +2598,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2496,7 +2619,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -2525,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -2536,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2549,19 +2672,13 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
 ]
-
-[[package]]
-name = "rust-fuzzy-search"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
 
 [[package]]
 name = "rustc-hash"
@@ -2589,11 +2706,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2614,25 +2731,24 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2642,13 +2758,40 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2662,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2680,9 +2823,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2695,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2734,11 +2877,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2747,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2793,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.147"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af14725505314343e673e9ecb7cd7e8a36aa9791eb936235a3567cc31447ae4"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
@@ -2855,13 +2998,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-rc.4",
+ "digest 0.11.1",
 ]
 
 [[package]]
@@ -2910,21 +3053,21 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2944,13 +3087,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -2976,9 +3125,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3007,12 +3156,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3029,11 +3178,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3049,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3069,30 +3218,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3125,9 +3274,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -3135,7 +3284,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -3143,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3168,15 +3317,15 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3185,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3198,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.10+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3222,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -3237,9 +3386,9 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64",
@@ -3263,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -3274,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3297,7 +3446,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -3366,16 +3515,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry",
- "opentelemetry_sdk",
- "rustversion",
  "smallvec",
- "thiserror 2.0.17",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -3434,15 +3580,21 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3458,9 +3610,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3476,11 +3628,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3531,18 +3683,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3553,11 +3714,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -3566,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3576,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3589,18 +3751,40 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3610,10 +3794,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3630,10 +3826,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.4"
+name = "webpki-root-certs"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3708,6 +3904,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3740,6 +3945,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3777,6 +3997,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3789,6 +4015,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3798,6 +4030,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3825,6 +4063,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3834,6 +4078,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3849,6 +4099,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3858,6 +4114,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3873,9 +4135,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "wiremock"
@@ -3902,9 +4164,91 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -3914,9 +4258,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x509-parser"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -3925,7 +4269,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -3966,18 +4310,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4016,9 +4360,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4060,6 +4404,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "0.1.9"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0095ecd462946aa3927d9297b63ef82fb9a5316d7a37d134eeb36e58228615a"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ arc-swap = "1.7"
 argh = "0.1"
 argon2 = "0.5"
 async-trait = "0.1"
-aws-sdk-s3 = { version = "1.115" }
+aws-sdk-s3 = { version = "1.125" }
 base64 = "0.22"
 bytes = "1.11"
 bytesize = { version = "2.3", features = ["serde"] }
@@ -25,7 +25,7 @@ http-body-util = "0.1"
 humantime = "2.3"
 hyper = { version = "1.8" , features = ["full"]}
 hyper-util = { version = "0.1", features = ["tokio", "server-graceful"] }
-jsonwebtoken = { version = "10.2", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "10.3", features = ["aws_lc_rs"] }
 mime_guess = "2.0"
 notify = "8.2"
 parking_lot = "0.12"
@@ -35,24 +35,24 @@ opentelemetry-otlp = { version = "0.31" , features = ["grpc-tonic"]}
 prometheus = "0.14"
 redis = { version = "1.0", features = ["tokio-comp"] }
 regex = "1.12"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "stream", "json"] }
 rpassword = "7.4"
-rust-embed = "8.5"
+rust-embed = "8.11"
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
-rustls-pki-types = "1.13"
+rustls-pki-types = "1.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
-sha2 = "0.11.0-rc.3"
-tempfile = "3.23"
-tokio = { version = "1.48", features = ["full", "tracing"] }
+sha2 = "0.11.0-rc.5"
+tempfile = "3.27"
+tokio = { version = "1.50", features = ["full", "tracing"] }
 tokio-rustls = "0.26"
 tokio-util = { version = "0.7", features = ["io-util"] }
 toml = "0.9"
 tracing = "0.1"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-uuid = { version = "1.18", features = ["v4", "serde"] }
+uuid = { version = "1.22", features = ["v4", "serde"] }
 x509-parser = "0.18"
 zeroize = { version = "1.8", features = ["derive"] }
 

--- a/conformance/config-s3-lock.toml
+++ b/conformance/config-s3-lock.toml
@@ -1,0 +1,33 @@
+[server]
+bind_address = "0.0.0.0"
+port = 8000
+
+[global]
+# 307 temporary redirections are not defined in the OCI spec, so zb don't (seems to) support 307 it.
+enable_redirect = false
+
+[blob_store.s3]
+# Test credentials for local MinIO instance
+access_key_id = "root"
+secret_key = "roottoor"
+endpoint = "http://127.0.0.1:9000"
+bucket = "registry"
+region = "region"
+multipart_copy_threshold = "5GiB"
+multipart_copy_chunk_size = "100MiB"
+multipart_copy_jobs = 10
+
+[metadata_store.s3]
+# Test credentials for local MinIO instance
+access_key_id = "root"
+secret_key = "roottoor"
+endpoint = "http://127.0.0.1:9000"
+bucket = "registry"
+region = "region"
+
+[metadata_store.s3.lock_strategy.s3]
+
+[global.access_policy]
+default_allow = true
+
+[repository."conformance"]

--- a/conformance/config-s3-lock.toml
+++ b/conformance/config-s3-lock.toml
@@ -25,6 +25,9 @@ endpoint = "http://127.0.0.1:9000"
 bucket = "registry"
 region = "region"
 
+link_cache_ttl = 0
+access_time_debounce_secs = 0
+
 [metadata_store.s3.lock_strategy.s3]
 
 [global.access_policy]

--- a/doc/explanation/architecture.md
+++ b/doc/explanation/architecture.md
@@ -187,6 +187,7 @@ Built on Tokio with configurable parallelism:
 Distributed locking for multi-replica deployments:
 - In-memory locks for single instance
 - Redis locks for multiple instances
+- S3 locks for multiple instances using conditional writes (no extra infrastructure needed)
 
 ---
 

--- a/doc/explanation/authentication-authorization.md
+++ b/doc/explanation/authentication-authorization.md
@@ -143,7 +143,7 @@ sequenceDiagram
     Policy-->>Registry: Allow/Deny
 
     opt Webhook configured
-        Registry->>Webhook: GET /authorize
+        Registry->>Webhook: POST <configured webhook URL>
         Webhook-->>Registry: 2xx (allow) or other (deny)
     end
 
@@ -257,7 +257,7 @@ sequenceDiagram
     participant Registry
     participant Webhook
 
-    Registry->>Webhook: GET /authorize
+    Registry->>Webhook: POST <configured webhook URL>
     Note right of Webhook: Headers contain request context
     Webhook-->>Registry: 200 OK (allow)
     Webhook-->>Registry: 403 Forbidden (deny)

--- a/doc/explanation/storage-backends.md
+++ b/doc/explanation/storage-backends.md
@@ -399,6 +399,8 @@ Access time updates (`last_pulled_at`) are buffered in memory and flushed to S3 
 - If an instance crashes before flushing, those buffered updates are lost.
 - Multiple instances may overwrite each other's access times (last writer wins).
 
+> **S3 Lock Performance:** When using S3 lock strategy, setting `access_time_debounce_secs = 0` disables buffering and causes every manifest pull to perform a lock-acquire → read → write → release cycle. This is particularly expensive with S3 locking and should be avoided in production. Use the default debounce value (60s or higher) for S3-locked deployments.
+
 For retention policies that use `last_pulled_at`, set thresholds in **days rather than minutes** to account for this imprecision. For example:
 
 ```toml

--- a/doc/explanation/storage-backends.md
+++ b/doc/explanation/storage-backends.md
@@ -309,6 +309,22 @@ Lock is held during:
 - Blob link creation
 - Upload completion
 
+### Monitoring Lock Operations
+
+Lock operations emit Prometheus metrics for observability. Key metrics to monitor:
+
+- `lock_acquisition_duration_ms` — Histogram of lock acquisition times (e.g., p99 > 500ms indicates S3 latency degradation)
+- `lock_retries_total` — Counter of lock acquisition retries (e.g., rising rate indicates lock contention)
+- `lock_invalidations_total{reason="heartbeat_failure"}` — Stale heartbeat failures (e.g., indicates S3 connectivity issues)
+- `lock_recoveries_total` — Counter of stale lock recovery attempts (e.g., indicates crashed instances)
+
+For multi-instance deployments, alert on:
+- **High `lock_retries_total` rate**: Rising retry rate during normal operation suggests lock contention and may indicate insufficient `max_retries` or `retry_delay_ms` tuning.
+- **`lock_invalidations_total{reason="heartbeat_failure"}`**: Heartbeat failures suggest network issues between the registry and S3. Consider checking S3 connectivity, network quality, and lock timeout settings.
+- **High `lock_acquisition_duration_ms` p99**: Persistent p99 latency > expected S3 latency may indicate saturation or regional latency issues.
+
+See the [configuration reference](../reference/configuration.md#prometheus-metrics) for the full metrics list.
+
 ---
 
 ## Multi-Instance Consistency

--- a/doc/explanation/storage-backends.md
+++ b/doc/explanation/storage-backends.md
@@ -289,6 +289,8 @@ retry_delay_ms = 10         # Delay between retries
 
 Available only when using S3 for metadata (not supported with filesystem metadata stores). Uses conditional writes (`If-None-Match: *`) to implement distributed locks directly in the S3 bucket, eliminating the need for Redis. Stale locks are automatically recovered after TTL expiry.
 
+Lock operations use a dedicated S3 client with independent timeout configuration, separate from the metadata store's main S3 client. This allows tuning lock behavior independently — lock operations should fail fast rather than blocking for minutes, which is important in high-latency S3 scenarios.
+
 ```toml
 [metadata_store.s3.lock_strategy.s3]
 ttl_secs = 30               # Lock expiry in seconds (minimum: 3)

--- a/doc/explanation/storage-backends.md
+++ b/doc/explanation/storage-backends.md
@@ -46,8 +46,10 @@ sequenceDiagram
         Registry->>Lock: Acquire lock
         alt Single instance
             Lock->>Lock: In-memory lock
-        else Multi-replica
+        else Multi-replica (Redis)
             Lock->>Redis: Distributed lock
+        else Multi-replica (S3)
+            Lock->>S3: Conditional write lock
         end
     end
 
@@ -178,7 +180,7 @@ operation_attempt_timeout_secs = 300
 - Higher latency than local disk
 - Network dependency
 - Potential egress costs
-- Requires Redis for locking
+- Requires distributed locking configuration for multi-replica
 
 ### Compatible Services
 
@@ -196,7 +198,30 @@ operation_attempt_timeout_secs = 300
 
 For multiple registry instances, you need:
 1. **Shared storage**: S3 or shared filesystem
-2. **Distributed locking**: Redis
+2. **Distributed locking**: Redis or S3
+
+### With S3 Locking (Simplest)
+
+Uses S3 conditional writes (`If-None-Match: *`) for locking — no extra infrastructure required. The S3 provider must support conditional writes; Angos verifies this at startup.
+
+```toml
+[blob_store.s3]
+bucket = "registry-data"
+# ... S3 config
+
+[metadata_store.s3]
+bucket = "registry-data"
+# ... S3 config
+```
+
+To customize lock behavior:
+
+```toml
+[metadata_store.s3.lock_strategy.s3]
+ttl_secs = 30          # Lock expiry (default: 30)
+max_retries = 100      # Acquisition attempts (default: 100)
+retry_delay_ms = 50    # Delay between retries (default: 50)
+```
 
 ### With S3 + Redis
 
@@ -209,7 +234,7 @@ bucket = "registry-data"
 bucket = "registry-data"
 # ... S3 config
 
-[metadata_store.s3.redis]
+[metadata_store.s3.lock_strategy.redis]
 url = "redis://redis:6379"
 ttl = 10
 key_prefix = "registry-locks"
@@ -227,7 +252,7 @@ root_dir = "/mnt/nfs/registry"
 [metadata_store.fs]
 root_dir = "/mnt/nfs/registry"
 
-[metadata_store.fs.redis]
+[metadata_store.fs.lock_strategy.redis]
 url = "redis://redis:6379"
 ttl = 10
 
@@ -247,10 +272,10 @@ url = "redis://redis:6379"
 
 ### Redis Locking
 
-Required for multi-replica:
+Suitable for multi-replica with any storage backend:
 
 ```toml
-[metadata_store.fs.redis]
+[metadata_store.fs.lock_strategy.redis]
 url = "redis://redis:6379"
 ttl = 10                    # Lock timeout in seconds
 key_prefix = "locks"        # Optional prefix
@@ -258,10 +283,111 @@ max_retries = 100           # Retry attempts
 retry_delay_ms = 10         # Delay between retries
 ```
 
+**Legacy form:** The `[metadata_store.*.redis]` table (e.g., `[metadata_store.fs.redis]`) is still accepted for backward compatibility and is equivalent to `[metadata_store.*.lock_strategy.redis]`. New configurations should use the `lock_strategy` form.
+
+### S3 Locking
+
+Available only when using S3 for metadata (not supported with filesystem metadata stores). Uses conditional writes (`If-None-Match: *`) to implement distributed locks directly in the S3 bucket, eliminating the need for Redis. Stale locks are automatically recovered after TTL expiry.
+
+```toml
+[metadata_store.s3.lock_strategy.s3]
+ttl_secs = 30               # Lock expiry in seconds (minimum: 3)
+max_retries = 100           # Acquisition retry attempts
+retry_delay_ms = 50         # Delay between retries (minimum: 1)
+```
+
+The heartbeat interval is automatically calculated as `ttl_secs / 3`. For example, with the default `ttl_secs = 30`, heartbeats occur every 10 seconds. The minimum `ttl_secs` value is 3 seconds, resulting in a minimum heartbeat interval of 1 second.
+
+:::note
+The S3 provider must support conditional writes. Angos probes for this capability at startup and fails fast if it is not available.
+:::
+
 Lock is held during:
 - Manifest writes (tag updates)
 - Blob link creation
 - Upload completion
+
+---
+
+## Multi-Instance Consistency
+
+When multiple Angos instances share an S3 metadata backend, locking guarantees write safety but caching introduces read consistency trade-offs. This section covers what to expect and how to tune for your requirements.
+
+### Cache Modes
+
+By default, Angos caches link metadata (tags, layer links) in memory. Each instance maintains its own cache, so a write on instance A is not visible to instance B until the cache entry expires or is evicted. The `link_cache_ttl` setting (default 30 s) controls how long stale entries persist.
+
+**Option 1: Redis cache (recommended for multi-instance)**
+
+A shared Redis cache eliminates cross-instance staleness. When instance A writes a tag, instance B sees the updated cache entry immediately because both share the same Redis-backed store.
+
+```toml
+[blob_store.s3]
+bucket = "my-registry"
+endpoint = "https://s3.amazonaws.com"
+region = "us-east-1"
+
+[metadata_store.s3]
+bucket = "my-registry"
+endpoint = "https://s3.amazonaws.com"
+region = "us-east-1"
+
+[metadata_store.s3.lock_strategy.s3]
+
+[cache.redis]
+url = "redis://redis:6379"
+```
+
+**Option 2: Reduced TTL (no Redis required)**
+
+If adding Redis is not practical, reduce `link_cache_ttl` to shrink the staleness window. A lower TTL increases S3 read traffic but keeps all infrastructure in S3.
+
+```toml
+[blob_store.s3]
+bucket = "my-registry"
+endpoint = "https://s3.amazonaws.com"
+region = "us-east-1"
+
+[metadata_store.s3]
+bucket = "my-registry"
+endpoint = "https://s3.amazonaws.com"
+region = "us-east-1"
+link_cache_ttl = 5  # 5 seconds instead of 30
+
+[metadata_store.s3.lock_strategy.s3]
+```
+
+Setting `link_cache_ttl = 0` disables the cache entirely and always reads from S3.
+
+### S3 Lock Recovery
+
+S3 locks use a TTL (default 30 seconds, minimum 3 seconds) with automatic heartbeat renewal at `ttl_secs / 3` intervals. Under normal operation the holder renews the lock before it expires. If an instance crashes while holding a lock, other instances must wait for the full TTL to elapse before the lock is recovered. You can tune this trade-off:
+
+- **Lower `ttl_secs`** (e.g., 15): faster recovery after a crash, but more frequent heartbeat writes (at 5 s intervals).
+- **Higher `ttl_secs`** (e.g., 60): fewer heartbeat writes (at 20 s intervals), but longer recovery time.
+
+```toml
+[metadata_store.s3.lock_strategy.s3]
+ttl_secs = 15          # Faster crash recovery
+max_retries = 100
+retry_delay_ms = 50
+```
+
+### Access Times and Retention Policies
+
+Access time updates (`last_pulled_at`) are buffered in memory and flushed to S3 every `access_time_debounce_secs` seconds (default 60). In a multi-instance deployment, each instance maintains its own buffer. This means:
+
+- Access times may lag behind actual pulls by up to `access_time_debounce_secs`.
+- If an instance crashes before flushing, those buffered updates are lost.
+- Multiple instances may overwrite each other's access times (last writer wins).
+
+For retention policies that use `last_pulled_at`, set thresholds in **days rather than minutes** to account for this imprecision. For example:
+
+```toml
+# Safe: 30-day threshold tolerates access time imprecision
+[global.retention_policy]
+rules = ["manifest.last_pulled_at < now() - days(30)"]
+```
 
 ---
 
@@ -387,13 +513,14 @@ Without Redis, cache is in-memory per-instance.
 
 ## Decision Matrix
 
-| Requirement        | Filesystem    | S3 |
-|--------------------|---------------|----|
-| Single instance    | ✅             | ✅ |
-| Multiple instances | ❌ (needs NFS) | ✅ |
-| High availability  | ❌             | ✅ |
-| Low latency        | ✅             | ❌ |
-| Simple setup       | ✅             | ❌ |
-| Cost (small scale) | ✅             | ❌ |
-| Cost (large scale) | ❌             | ✅ |
-| Unlimited storage  | ❌             | ✅ |
+| Requirement        | Filesystem     | S3              |
+|--------------------|----------------|-----------------|
+| Single instance    | ✅             | ✅               |
+| Multiple instances | ❌ (needs NFS) | ✅               |
+| High availability  | ❌             | ✅               |
+| Low latency        | ✅             | ❌               |
+| Native locking     | ✅ (in-memory) | ✅ (S3 or Redis) |
+| Simple setup       | ✅             | ❌               |
+| Cost (small scale) | ✅             | ❌               |
+| Cost (large scale) | ❌             | ✅               |
+| Unlimited storage  | ❌             | ✅               |

--- a/doc/explanation/storage-backends.md
+++ b/doc/explanation/storage-backends.md
@@ -293,12 +293,12 @@ Lock operations use a dedicated S3 client with independent timeout configuration
 
 ```toml
 [metadata_store.s3.lock_strategy.s3]
-ttl_secs = 30               # Lock expiry in seconds (minimum: 3)
+ttl_secs = 30               # Lock expiry in seconds (minimum: 9)
 max_retries = 100           # Acquisition retry attempts
 retry_delay_ms = 50         # Delay between retries (minimum: 1)
 ```
 
-The heartbeat interval is automatically calculated as `ttl_secs / 3`. For example, with the default `ttl_secs = 30`, heartbeats occur every 10 seconds. The minimum `ttl_secs` value is 3 seconds, resulting in a minimum heartbeat interval of 1 second.
+The heartbeat interval is automatically calculated as `ttl_secs / 3`. For example, with the default `ttl_secs = 30`, heartbeats occur every 10 seconds. The minimum `ttl_secs` value is 9 seconds, resulting in a minimum heartbeat interval of 3 seconds.
 
 :::note
 The S3 provider must support conditional writes. Angos probes for this capability at startup and fails fast if it is not available.
@@ -480,7 +480,7 @@ multipart_copy_jobs = 4
 
 ### S3 Metadata Optimizations
 
-When using S3 for metadata, Angos includes two optimizations to reduce round-trips:
+When using S3 for metadata, Angos includes several optimizations to reduce round-trips and improve scalability:
 
 **Link cache** — A read-through cache for link metadata (tags, layer links). Populated on both read and write, invalidated on delete. Configurable TTL (default 30 s, `link_cache_ttl = 0` to disable). Shares the same cache backend (in-memory or Redis) as authentication tokens.
 
@@ -492,6 +492,72 @@ When using S3 for metadata, Angos includes two optimizations to reduce round-tri
 link_cache_ttl = 30               # seconds (0 to disable)
 access_time_debounce_secs = 60    # seconds (0 to disable)
 ```
+
+#### Blob Index Sharding
+
+Blob indexes track which namespaces reference each blob and are critical for garbage collection. Rather than storing a single `index.json` per blob (which becomes a contention point under concurrent access), Angos uses a **sharded approach**:
+
+Each blob's index is stored as multiple per-namespace files at:
+
+```
+v2/blobs/{algorithm}/{hash_prefix}/{hash}/refs/{namespace}.json
+```
+
+For example, a blob referenced by namespaces `myapp` and `team/backend` stores:
+
+```
+v2/blobs/sha256/ab/cdef.../refs/myapp.json
+v2/blobs/sha256/ab/cdef.../refs/team%2Fbackend.json
+```
+
+The namespace is percent-encoded in the filename (`/` → `%2F`, `%` → `%25`) to avoid ambiguity.
+
+**Benefits:**
+
+- **Reduced contention** — Multiple namespaces can update their blob references concurrently without serializing on a single file.
+- **Faster updates** — Each shard is small, making updates quicker.
+- **Scalability** — Performance doesn't degrade as the number of namespaces grows.
+
+#### Namespace Registry
+
+Listing all namespaces requires discovering all repositories and their nested namespaces. Without optimization, this is an O(n) tree walk across S3, which scales poorly.
+
+Angos maintains an index at:
+
+```
+_registry/namespaces.json
+```
+
+This file contains a simple JSON list:
+
+```json
+{
+  "namespaces": ["myapp", "team/backend", "team/frontend"]
+}
+```
+
+The registry is:
+
+- **Built on first use** — If missing, Angos performs an S3 tree walk to discover all namespaces and writes the registry file.
+- **Updated incrementally** — New namespaces are appended to the registry as they are created.
+- **Protected by locking** — Concurrent writes use distributed locking (S3 conditional writes or a lock key) to prevent corruption.
+
+**Benefits:**
+
+- **O(1) list performance** — Instead of O(n) tree walk, `list_namespaces` becomes a single file read.
+- **No background jobs** — The registry is built on demand, not via a separate garbage collector or background process.
+
+#### Legacy Blob Index Migration
+
+Angos deployed before version v1.1.0 used a single `index.json` file per blob. This is automatically migrated to the sharded format on first read with no manual intervention:
+
+1. Registry reads blob metadata and finds no sharded index files
+2. Falls back to reading the legacy `v2/blobs/{algorithm}/{hash_prefix}/{hash}/index.json`
+3. Writes each namespace's references to its own shard file
+4. Deletes the legacy `index.json`
+5. Subsequent reads use the sharded format
+
+The migration is transparent and happens exactly once per blob. You can verify migration progress by monitoring S3 operations or checking logs for "Migrated legacy blob index" messages.
 
 ### Caching
 

--- a/doc/how-to/deploy-docker-compose.md
+++ b/doc/how-to/deploy-docker-compose.md
@@ -224,13 +224,62 @@ root_dir = "/data"
 [metadata_store.fs]
 root_dir = "/data"
 
-[metadata_store.fs.redis]
+[metadata_store.fs.lock_strategy.redis]
 url = "redis://redis:6379"
 ttl = 10
 
 [cache.redis]
 url = "redis://redis:6379"
 ```
+
+---
+
+## With S3 Locking for Multi-Replica
+
+If your S3 provider supports conditional writes, you can run multiple replicas without Redis by using S3-based locking.
+
+### docker-compose.yml
+
+```yaml
+version: '3.8'
+
+services:
+  registry:
+    image: ghcr.io/project-angos/angos:latest
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./config:/config:ro
+    command: ["-c", "/config/config.toml", "server"]
+    restart: unless-stopped
+    deploy:
+      replicas: 2
+```
+
+### Configuration
+
+```toml
+[server]
+bind_address = "0.0.0.0"
+port = 5000
+
+[blob_store.s3]
+bucket = "my-registry"
+endpoint = "https://s3.amazonaws.com"
+region = "us-east-1"
+
+[metadata_store.s3]
+bucket = "my-registry"
+endpoint = "https://s3.amazonaws.com"
+region = "us-east-1"
+
+[metadata_store.s3.lock_strategy.s3]
+ttl_secs = 30
+max_retries = 100
+retry_delay_ms = 50
+```
+
+At startup, Angos probes the S3 provider to verify conditional write support. If the probe fails, check that your provider supports `If-None-Match` headers or fall back to the Redis-based setup above.
 
 ---
 

--- a/doc/how-to/deploy-kubernetes.md
+++ b/doc/how-to/deploy-kubernetes.md
@@ -127,13 +127,13 @@ spec:
               mountPath: /data
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 5000
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: 5000
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -361,7 +361,7 @@ spec:
 ### Update Configuration
 
 ```toml
-[metadata_store.s3.redis]
+[metadata_store.s3.lock_strategy.redis]
 url = "redis://redis:6379"
 ttl = 10
 

--- a/doc/how-to/run-storage-maintenance.md
+++ b/doc/how-to/run-storage-maintenance.md
@@ -300,6 +300,23 @@ The `--media-types` flag reads each manifest blob and writes its `media_type` in
 
 This is idempotent and safe to run multiple times.
 
+### Automatic Blob Index Migration
+
+When the S3 backend reads blob metadata, it automatically migrates legacy single-file blob indexes (`index.json`) to the per-namespace shard format (`refs/{namespace}.json`). This migration is:
+
+- **Transparent** - Requires no operator action
+- **Idempotent** - Safe to run multiple times
+- **Crash-safe** - Shard files are written before the legacy file is deleted
+
+The `scrub --blobs` command triggers this migration as part of its normal blob iteration, making it an effective way to batch-migrate all legacy indexes:
+
+```bash
+# Migrate all legacy blob indexes to the new shard format
+./angos -c config.toml scrub --blobs
+```
+
+Running this once after upgrading will convert any remaining legacy `index.json` files to the sharded format automatically.
+
 ### Fix Links Format
 
 The `--links` flag repairs link format inconsistencies. Use this when:

--- a/doc/how-to/set-up-access-control.md
+++ b/doc/how-to/set-up-access-control.md
@@ -278,5 +278,34 @@ RUST_LOG=angos::registry::access_policy=debug \
 
 ## Reference
 
+### Available Actions
+
+| Action              | Description                          |
+|---------------------|--------------------------------------|
+| `healthz`           | Health check endpoint                |
+| `readyz`            | Readiness check endpoint             |
+| `metrics`           | Prometheus metrics endpoint          |
+| `get-api-version`   | API version check                    |
+| `start-upload`      | Start blob upload                    |
+| `get-upload`        | Get upload status                    |
+| `update-upload`     | Continue chunked upload              |
+| `complete-upload`   | Complete upload                      |
+| `cancel-upload`     | Cancel upload                        |
+| `get-blob`          | Download blob                        |
+| `delete-blob`       | Delete blob                          |
+| `get-manifest`      | Pull manifest                        |
+| `put-manifest`      | Push manifest                        |
+| `delete-manifest`   | Delete manifest                      |
+| `get-referrers`     | Get referrers                        |
+| `list-catalog`      | List repositories (OCI catalog)      |
+| `list-tags`         | List tags                            |
+| `list-repositories` | Extension: list configured repos     |
+| `list-namespaces`   | Extension: list namespaces in a repo |
+| `list-revisions`    | Extension: list manifest revisions   |
+| `list-uploads`      | Extension: list uploads in progress  |
+| `ui-asset`          | UI static assets                     |
+| `ui-config`         | UI configuration                     |
+| `unknown`           | Unrecognized request                 |
+
 - [CEL Expressions Reference](../reference/cel-expressions.md) - All variables and functions
 - [Configuration Reference](../reference/configuration.md) - Policy configuration options

--- a/doc/how-to/troubleshoot-common-issues.md
+++ b/doc/how-to/troubleshoot-common-issues.md
@@ -251,10 +251,10 @@ sudo chown -R $(id -u):$(id -g) /data/registry
 
 **Cause**: Concurrent operations on same resource.
 
-**Solutions**:
-1. For multi-replica, configure Redis locking:
+**Solutions for Redis locking**:
+1. Configure Redis locking (use `lock_strategy.redis` form):
    ```toml
-   [metadata_store.fs.redis]
+   [metadata_store.fs.lock_strategy.redis]
    url = "redis://localhost:6379"
    ttl = 10
    max_retries = 100
@@ -262,6 +262,24 @@ sudo chown -R $(id -u):$(id -g) /data/registry
 
 2. Increase retry settings
 3. Check for stuck processes
+
+**Solutions for S3 locking**:
+1. Stale locks under the `_locks/` prefix are automatically recovered after TTL expiry
+2. If operations take longer than the TTL, increase `ttl_secs` (minimum: 3):
+   ```toml
+   [metadata_store.s3.lock_strategy.s3]
+   ttl_secs = 60
+   ```
+   The heartbeat interval is automatically set to `ttl_secs / 3`, so this example will heartbeat every 20 seconds.
+
+3. For high contention, increase `max_retries` and `retry_delay_ms`:
+   ```toml
+   [metadata_store.s3.lock_strategy.s3]
+   max_retries = 200
+   retry_delay_ms = 100
+   ```
+
+4. If the startup probe fails, your S3 provider may not support conditional writes — fall back to Redis locking instead. S3 locking is only supported when using S3 for metadata storage; it cannot be used with filesystem metadata stores.
 
 ---
 

--- a/doc/how-to/troubleshoot-common-issues.md
+++ b/doc/how-to/troubleshoot-common-issues.md
@@ -265,7 +265,7 @@ sudo chown -R $(id -u):$(id -g) /data/registry
 
 **Solutions for S3 locking**:
 1. Stale locks under the `_locks/` prefix are automatically recovered after TTL expiry
-2. If operations take longer than the TTL, increase `ttl_secs` (minimum: 3):
+2. If operations take longer than the TTL, increase `ttl_secs` (minimum: 9):
    ```toml
    [metadata_store.s3.lock_strategy.s3]
    ttl_secs = 60

--- a/doc/reference/api-endpoints.md
+++ b/doc/reference/api-endpoints.md
@@ -250,6 +250,29 @@ Use this for Kubernetes readiness probes to detect when a replica is unable to s
 {"status":"ready"}
 ```
 
+Add `?verbose=true` to the query string to include conditional operation capabilities (S3 metadata store only):
+
+```
+GET /readyz?verbose=true
+```
+
+**Verbose Success Response (S3 metadata store):**
+```json
+{
+  "status": "ready",
+  "conditional": {
+    "put_if_none_match": true,
+    "put_if_match": true,
+    "delete_if_match": true
+  }
+}
+```
+
+**Verbose Success Response (filesystem metadata store):**
+```json
+{"status":"ready"}
+```
+
 **Service Unavailable Response (503):**
 ```json
 {"status":"not_ready","error":"storage backend not ready: ..."}

--- a/doc/reference/api-endpoints.md
+++ b/doc/reference/api-endpoints.md
@@ -227,13 +227,33 @@ List blob uploads in progress.
 
 ## Health and Metrics
 
-### Health Check
+### Health Check (Liveness)
 
 ```
 GET /healthz
 ```
 
-Returns `200 OK` if the service is healthy.
+Returns `200 OK` if the service is running. Use this for Kubernetes liveness probes to detect hung processes.
+
+### Readiness Check
+
+```
+GET /readyz
+```
+
+Returns `200 OK` if the storage backend is healthy and ready to handle requests. Checks accessibility of the blob store, metadata store, and lock backend.
+
+Use this for Kubernetes readiness probes to detect when a replica is unable to serve traffic.
+
+**Success Response:**
+```json
+{"status":"ready"}
+```
+
+**Service Unavailable Response (503):**
+```json
+{"status":"not_ready","error":"storage backend not ready: ..."}
+```
 
 ### Prometheus Metrics
 
@@ -278,7 +298,7 @@ Returns UI configuration.
 
 ## Authentication
 
-All endpoints (except `/healthz`) require authentication when access policies are configured.
+All endpoints (except `/healthz` and `/readyz`) require authentication when access policies are configured.
 
 ### Methods
 

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -17,6 +17,7 @@ Most configuration changes take effect immediately without restart. The followin
 - `observability.tracing.sampling_rate`
 - Enabling or disabling TLS
 - Changing storage backend type (filesystem ↔ S3)
+- Changing lock strategy
 
 TLS certificate files are also automatically reloaded when they change.
 
@@ -119,27 +120,93 @@ Choose one: `blob_store.fs` or `blob_store.s3`.
 
 Optional. Defaults to same backend as blob store.
 
+### Lock Strategy Compatibility
+
+The following table shows which lock strategies are supported with each metadata store backend:
+
+| Lock Strategy | S3 metadata store | FS metadata store |
+|---------------|-------------------|-------------------|
+| memory        | Yes               | Yes               |
+| redis         | Yes               | Yes               |
+| s3            | Yes               | No                |
+
 ### Filesystem (`metadata_store.fs`)
 
-| Option         | Type   | Default  | Description                                     |
-|----------------|--------|----------|-------------------------------------------------|
-| `root_dir`     | string | -        | Directory for metadata (defaults to blob store) |
-| `sync_to_disk` | bool   | `false`  | Force fsync after writes                        |
+| Option         | Type         | Default    | Description                                     |
+|----------------|--------------|------------|-----------------------------------------------|
+| `root_dir`     | string       | -          | Directory for metadata (defaults to blob store) |
+| `sync_to_disk` | bool         | `false`    | Force fsync after writes                        |
+| `lock_strategy` | string/table | `"memory"` | Lock backend: `"memory"` (string), or `[lock_strategy.redis]` (table form). S3 locking not supported. |
+
+> **Note:** The S3 lock strategy is not supported for filesystem metadata stores. Use `"memory"` for single-instance deployments or `[lock_strategy.redis]` for multi-replica deployments.
 
 ### S3 (`metadata_store.s3`)
 
 Same connection options as `blob_store.s3`, plus:
 
-| Option                      | Type | Default | Description                                                                 |
-|-----------------------------|------|---------|-----------------------------------------------------------------------------|
-| `link_cache_ttl`            | u64  | `30`    | Read-through cache TTL for link metadata, in seconds (0 to disable)         |
-| `access_time_debounce_secs` | u64  | `60`    | Buffer access time writes and flush periodically, in seconds (0 to disable) |
+| Option                      | Type         | Default    | Description                                                                 |
+|-----------------------------|--------------|------------|-----------------------------------------------------------------------------|
+| `link_cache_ttl`            | u64          | `30`       | Read-through cache TTL for link metadata, in seconds (0 to disable)         |
+| `access_time_debounce_secs` | u64          | `60`       | Buffer access time writes and flush periodically, in seconds (0 to disable) |
+| `lock_strategy`             | string/table | `"memory"` | Lock backend: `"memory"` (string), or `[lock_strategy.s3]`/`[lock_strategy.redis]` (table form, see below) |
 
 The link cache reduces S3 round-trips for repeated tag/layer reads. The access time debounce batches `last_pulled_at` timestamp writes in memory and flushes them periodically, reducing the critical-path operations per manifest pull from 4 (lock, read, write, unlock) to 1 (read).
 
-### Distributed Locking (`metadata_store.*.redis`)
+### Distributed Locking
 
-Required for multi-replica deployments.
+Multi-replica deployments require a distributed lock backend. The `lock_strategy` field on the metadata store selects the backend. Three options are available:
+
+**Lock Strategy Compatibility Matrix:**
+
+| Lock Strategy | S3 metadata | FS metadata |
+|---|---|---|
+| memory | Yes | Yes |
+| redis | Yes | Yes |
+| s3 | Yes | No |
+
+**Memory** (default) — in-process locks, suitable for single-instance deployments only:
+
+```toml
+[metadata_store.s3]
+lock_strategy = "memory"
+```
+
+**S3** — uses S3 conditional writes (`If-None-Match: *`) for distributed locking without extra infrastructure. The S3 provider must support conditional writes; angos verifies this at startup:
+
+```toml
+# With defaults (empty table body; all fields use defaults)
+[metadata_store.s3.lock_strategy.s3]
+
+# With custom settings
+[metadata_store.s3.lock_strategy.s3]
+ttl_secs = 30
+max_retries = 100
+retry_delay_ms = 50
+```
+
+> **Note:** The bare-string form `lock_strategy = "s3"` is not supported; use the table form `[metadata_store.s3.lock_strategy.s3]` to accept defaults or override individual fields.
+
+| Option           | Type | Default | Description                  |
+|------------------|------|---------|------------------------------|
+| `ttl_secs`       | u64  | `30`    | Lock TTL in seconds (minimum: 3). Heartbeat renews at intervals of `ttl_secs / 3` |
+| `max_retries`    | u32  | `100`   | Max lock acquisition retries |
+| `retry_delay_ms` | u64  | `50`    | Delay between retries (minimum: 1) |
+
+**Heartbeat Mechanism:**
+
+The S3 lock implementation uses a heartbeat to keep locks alive. Once acquired, a background task automatically renews the lock at regular intervals of `ttl_secs / 3`. For example, with the default `ttl_secs = 30`, the heartbeat runs every 10 seconds. This allows the lock to remain valid beyond the initial TTL as long as the lock-holder remains alive. If a lock-holder crashes, other instances must wait for the full `ttl_secs` duration before the lock becomes available for recovery.
+
+> **Contention note:** Under high concurrency with overlapping lock sets, instances may experience repeated rollbacks during lock acquisition. Increasing `max_retries` or reducing instance count mitigates this. Randomized jitter on retry delays desynchronises retrying instances.
+
+> **Clock synchronisation:** The lock implementation uses S3's server-side timestamps for expiry checks, so lock correctness does not depend on synchronised instance clocks. Registry instances should still maintain synchronised clocks (NTP) for logging and other operational reasons.
+
+**Redis** — distributed locking via Redis, suitable for multi-instance deployments:
+
+```toml
+[metadata_store.s3.lock_strategy.redis]
+url = "redis://localhost:6379"
+ttl = 10
+```
 
 | Option           | Type   | Default  | Description                  |
 |------------------|--------|----------|------------------------------|
@@ -148,6 +215,8 @@ Required for multi-replica deployments.
 | `key_prefix`     | string | -        | Prefix for lock keys         |
 | `max_retries`    | u32    | `100`    | Max lock acquisition retries |
 | `retry_delay_ms` | u64    | `10`     | Delay between retries        |
+
+> **Legacy form:** The `[metadata_store.*.redis]` table (e.g., `[metadata_store.s3.redis]`) is still accepted for backward compatibility and is equivalent to `[metadata_store.*.lock_strategy.redis]`. New configurations should use the `lock_strategy` form. Both forms cannot be set simultaneously.
 
 ---
 
@@ -311,7 +380,7 @@ root_dir = "/var/registry/blobs"
 [metadata_store.fs]
 root_dir = "/var/registry/metadata"
 
-[metadata_store.fs.redis]
+[metadata_store.fs.lock_strategy.redis]
 url = "redis://localhost:6379"
 ttl = 10
 
@@ -336,4 +405,39 @@ url = "https://registry-1.docker.io"
 [ui]
 enabled = true
 name = "My Registry"
+```
+
+### S3-Only Multi-Instance Deployment
+
+This example uses S3 for both blob and metadata storage with S3-based distributed locking, eliminating the need for Redis:
+
+```toml
+[server]
+bind_address = "0.0.0.0"
+port = 5000
+
+[global]
+update_pull_time = true
+
+[blob_store.s3]
+# Example credentials - replace for production
+access_key_id = "minioadmin"
+secret_key = "minioadmin"
+endpoint = "https://s3.example.com"
+bucket = "registry"
+region = "us-east-1"
+
+[metadata_store.s3]
+# Example credentials - replace for production
+access_key_id = "minioadmin"
+secret_key = "minioadmin"
+endpoint = "https://s3.example.com"
+bucket = "registry-metadata"
+region = "us-east-1"
+
+[metadata_store.s3.lock_strategy.s3]
+
+[auth.identity.admin]
+username = "admin"
+password = "$argon2id$v=19$m=19456,t=2,p=1$..."
 ```

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -340,6 +340,27 @@ Webhooks are enabled by referencing their names:
 | `endpoint`      | string | required | OpenTelemetry endpoint    |
 | `sampling_rate` | f64    | required | Sampling rate (0.0 - 1.0) |
 
+### Prometheus Metrics
+
+Angos emits Prometheus metrics on the `/metrics` endpoint. The following metrics are available for lock operations:
+
+**Lock Metrics:**
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `lock_acquisition_duration_ms` | Histogram | `backend` | Lock acquisition duration in milliseconds |
+| `lock_acquisitions_total` | Counter | `backend`, `result` | Total lock acquisition attempts |
+| `lock_retries_total` | Counter | `backend` | Total lock acquisition retries |
+| `lock_invalidations_total` | Counter | `backend`, `reason` | Total lock invalidations |
+| `lock_recoveries_total` | Counter | `backend`, `result` | Total stale lock recovery attempts |
+
+**Label Values:**
+
+- `backend`: `s3`, `redis`, `memory`
+- `result` (acquisitions): `success`, `timeout`, `error`
+- `result` (recoveries): `acquired`, `not_stale`, `failed`, `error`
+- `reason` (invalidations): `ownership_lost`, `max_hold`, `heartbeat_failure`, `etag_unavailable`, `file_disappeared`
+
 ---
 
 ## Web UI (`ui`)

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -190,14 +190,15 @@ retry_delay_ms = 50
 
 | Option                          | Type | Default | Description                  |
 |---------------------------------|------|---------|------------------------------|
-| `ttl_secs`                      | u64  | `30`    | Lock TTL in seconds (minimum: 3). Heartbeat renews at intervals of `ttl_secs / 3` |
+| `ttl_secs`                      | u64  | `30`    | Lock TTL in seconds (minimum: 9). Heartbeat renews at intervals of `ttl_secs / 3` |
 | `max_retries`                   | u32  | `100`   | Max lock acquisition retries |
 | `retry_delay_ms`                | u64  | `50`    | Delay between retries (minimum: 1) |
-| `operation_timeout_secs`        | u64  | `30`    | Total timeout for lock S3 operations |
-| `operation_attempt_timeout_secs`| u64  | `10`    | Per-attempt timeout for lock S3 operations |
-| `max_attempts`                  | u32  | `3`     | Maximum retry attempts for lock S3 operations |
+| `max_hold_secs`                 | u64  | `300`   | Maximum lock hold duration in seconds (minimum: 10, must be >= `ttl_secs`). Guard is invalidated if held beyond this duration |
+| `operation_timeout_secs`        | u64  | `15`    | Total timeout for lock S3 operations |
+| `operation_attempt_timeout_secs`| u64  | `4`     | Per-attempt timeout for lock S3 operations |
+| `max_attempts`                  | u32  | `2`     | Maximum retry attempts for lock S3 operations |
 
-> **Lock operation timeouts:** Lock operations use their own S3 client with significantly tighter timeouts than blob/metadata operations. This is intentional: lock operations are small JSON payloads and should fail fast rather than blocking for minutes on a stuck request. The defaults (`operation_timeout_secs = 30`, `operation_attempt_timeout_secs = 10`, `max_attempts = 3`) are tuned for lock-like behavior. For high-latency S3 scenarios, increase these values to match your network latency, but keep them much lower than the metadata store's main S3 client timeouts (default 900s/300s).
+> **Lock operation timeouts:** Lock operations use their own S3 client with significantly tighter timeouts than blob/metadata operations. This is intentional: lock operations are small JSON payloads and should fail fast rather than blocking for minutes on a stuck request. The defaults (`operation_timeout_secs = 15`, `operation_attempt_timeout_secs = 4`, `max_attempts = 2`) ensure that a single stuck request cannot consume an entire heartbeat interval (10s with default TTL). Each heartbeat tick is also capped to the heartbeat interval to prevent the slow path (two sequential SDK calls) from exceeding it. A startup warning is emitted if `operation_attempt_timeout_secs × max_attempts >= ttl_secs / 3`. For high-latency S3 scenarios, increase these values but keep `attempt_timeout × max_attempts` below the heartbeat interval.
 
 **Heartbeat Mechanism:**
 

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -149,8 +149,57 @@ Same connection options as `blob_store.s3`, plus:
 | `link_cache_ttl`            | u64          | `30`       | Read-through cache TTL for link metadata, in seconds (0 to disable)         |
 | `access_time_debounce_secs` | u64          | `60`       | Buffer access time writes and flush periodically, in seconds (0 to disable) |
 | `lock_strategy`             | string/table | `"memory"` | Lock backend: `"memory"` (string), or `[lock_strategy.s3]`/`[lock_strategy.redis]` (table form, see below) |
+| `capabilities`              | table        | -          | Optional S3 conditional operation capabilities; see below                    |
 
 The link cache reduces S3 round-trips for repeated tag/layer reads. The access time debounce batches `last_pulled_at` timestamp writes in memory and flushes them periodically, reducing the critical-path operations per manifest pull from 4 (lock, read, write, unlock) to 1 (read).
+
+#### Conditional Capabilities (`metadata_store.s3.capabilities`)
+
+When using S3 as the metadata store, you can declare which conditional write operations your S3-compatible provider supports. This avoids a startup probe and allows optimization of certain operations.
+
+| Option              | Type | Default | Description                                                                                                 |
+|---------------------|------|---------|-------------------------------------------------------------------------------------------------------------|
+| `put_if_none_match` | bool | -       | S3 supports `PutObject` with `If-None-Match: *` (create-only, reject if object exists)                     |
+| `put_if_match`      | bool | -       | S3 supports `PutObject` with `If-Match: <etag>` (update-only, reject if ETag mismatch)                     |
+| `delete_if_match`   | bool | -       | S3 supports `DeleteObject` with `If-Match: <etag>` (conditional delete, reject if ETag mismatch)          |
+
+**Probe behavior:**
+- When `capabilities` table is explicitly configured, the startup probe is skipped entirely. Provide accurate values matching your S3 provider's capabilities.
+- When `capabilities` is omitted:
+  - If `lock_strategy = "s3"`, a startup probe automatically tests each capability and populates the status.
+  - For other lock strategies, capabilities default to all `false` (no probing occurs).
+
+**Example with explicit capabilities (AWS S3):**
+```toml
+[metadata_store.s3.capabilities]
+put_if_none_match = true
+put_if_match = true
+delete_if_match = true
+```
+
+**Example with explicit capabilities (minimal, memory locking):**
+```toml
+[metadata_store.s3]
+lock_strategy = "memory"
+
+[metadata_store.s3.capabilities]
+put_if_none_match = false
+put_if_match = false
+delete_if_match = false
+```
+
+**Example with auto-probe (S3 locking):**
+```toml
+[metadata_store.s3]
+# No capabilities field — probe runs at startup for S3 lock strategy
+[metadata_store.s3.lock_strategy.s3]
+ttl_secs = 30
+```
+
+**Performance impact:**
+- When `put_if_match` is available, access time writes use optimized compare-and-swap (CAS) instead of distributed lock operations, reducing S3 API calls per manifest pull.
+- When `delete_if_match` is available, S3 lock release is atomic and race-condition-free.
+- Both features require both `put_if_none_match` and `put_if_match` to be `true` for full CAS support.
 
 > **Warning:** Setting `access_time_debounce_secs = 0` with S3 lock strategy causes every manifest pull to perform a full lock-acquire → read → write → release cycle via S3 API. At scale with many concurrent pulls, this adds significant latency and S3 API costs. Keep the default value of 60 or higher for S3-locked deployments, or disable access time tracking entirely if not needed for retention policies.
 

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -204,7 +204,7 @@ retry_delay_ms = 50
 
 The S3 lock implementation uses a heartbeat to keep locks alive. Once acquired, a background task automatically renews the lock at regular intervals of `ttl_secs / 3`. For example, with the default `ttl_secs = 30`, the heartbeat runs every 10 seconds. This allows the lock to remain valid beyond the initial TTL as long as the lock-holder remains alive. If a lock-holder crashes, other instances must wait for the full `ttl_secs` duration before the lock becomes available for recovery.
 
-> **Contention note:** Under high concurrency with overlapping lock sets, instances may experience repeated rollbacks during lock acquisition. Increasing `max_retries` or reducing instance count mitigates this. Randomized jitter on retry delays desynchronises retrying instances.
+> **Contention note:** The first lock acquisition attempt uses parallel PUTs for low latency. If any key is contended, the system falls back to sequential sorted acquisition for all subsequent retries, which eliminates circular wait and prevents livelock. When CAS blob index updates are active (S3 lock strategy), blob digest keys are excluded from locking, avoiding cross-namespace contention on shared layers. Randomized jitter on retry delays desynchronises retrying instances.
 
 > **Clock synchronisation:** The lock implementation uses S3's server-side timestamps for expiry checks, so lock correctness does not depend on synchronised instance clocks. Registry instances should still maintain synchronised clocks (NTP) for logging and other operational reasons.
 

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -152,6 +152,8 @@ Same connection options as `blob_store.s3`, plus:
 
 The link cache reduces S3 round-trips for repeated tag/layer reads. The access time debounce batches `last_pulled_at` timestamp writes in memory and flushes them periodically, reducing the critical-path operations per manifest pull from 4 (lock, read, write, unlock) to 1 (read).
 
+> **Warning:** Setting `access_time_debounce_secs = 0` with S3 lock strategy causes every manifest pull to perform a full lock-acquire → read → write → release cycle via S3 API. At scale with many concurrent pulls, this adds significant latency and S3 API costs. Keep the default value of 60 or higher for S3-locked deployments, or disable access time tracking entirely if not needed for retention policies.
+
 ### Distributed Locking
 
 Multi-replica deployments require a distributed lock backend. The `lock_strategy` field on the metadata store selects the backend. Three options are available:

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -186,11 +186,16 @@ retry_delay_ms = 50
 
 > **Note:** The bare-string form `lock_strategy = "s3"` is not supported; use the table form `[metadata_store.s3.lock_strategy.s3]` to accept defaults or override individual fields.
 
-| Option           | Type | Default | Description                  |
-|------------------|------|---------|------------------------------|
-| `ttl_secs`       | u64  | `30`    | Lock TTL in seconds (minimum: 3). Heartbeat renews at intervals of `ttl_secs / 3` |
-| `max_retries`    | u32  | `100`   | Max lock acquisition retries |
-| `retry_delay_ms` | u64  | `50`    | Delay between retries (minimum: 1) |
+| Option                          | Type | Default | Description                  |
+|---------------------------------|------|---------|------------------------------|
+| `ttl_secs`                      | u64  | `30`    | Lock TTL in seconds (minimum: 3). Heartbeat renews at intervals of `ttl_secs / 3` |
+| `max_retries`                   | u32  | `100`   | Max lock acquisition retries |
+| `retry_delay_ms`                | u64  | `50`    | Delay between retries (minimum: 1) |
+| `operation_timeout_secs`        | u64  | `30`    | Total timeout for lock S3 operations |
+| `operation_attempt_timeout_secs`| u64  | `10`    | Per-attempt timeout for lock S3 operations |
+| `max_attempts`                  | u32  | `3`     | Maximum retry attempts for lock S3 operations |
+
+> **Lock operation timeouts:** Lock operations use their own S3 client with significantly tighter timeouts than blob/metadata operations. This is intentional: lock operations are small JSON payloads and should fail fast rather than blocking for minutes on a stuck request. The defaults (`operation_timeout_secs = 30`, `operation_attempt_timeout_secs = 10`, `max_attempts = 3`) are tuned for lock-like behavior. For high-latency S3 scenarios, increase these values to match your network latency, but keep them much lower than the metadata store's main S3 client timeouts (default 900s/300s).
 
 **Heartbeat Mechanism:**
 

--- a/doc/tutorials/mirror-docker-hub.md
+++ b/doc/tutorials/mirror-docker-hub.md
@@ -111,7 +111,7 @@ curl http://localhost:5000/v2/docker-io/library/nginx/tags/list
 You should see:
 
 ```json
-{"name":"docker-io/library/nginx","tags":["1.29.0"]}
+{"name":"docker-io/library/nginx","tags":["1.25.0"]}
 ```
 
 ## Complete Configuration

--- a/src/cache/memory.rs
+++ b/src/cache/memory.rs
@@ -71,6 +71,12 @@ impl Cache for Backend {
 
         Ok(None)
     }
+
+    async fn delete_value(&self, key: &str) -> Result<(), Error> {
+        let mut store = self.store.write().await;
+        store.remove(key);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -20,6 +20,9 @@ pub trait Cache: Any + Debug + Send + Sync {
 
     /// Retrieve a value from the cache
     async fn retrieve_value(&self, key: &str) -> Result<Option<String>, Error>;
+
+    /// Remove a value from the cache immediately
+    async fn delete_value(&self, key: &str) -> Result<(), Error>;
 }
 
 /// Extension trait providing JSON serialization for cache operations
@@ -155,6 +158,12 @@ mod tests {
                 return Err(Error::Backend(error.clone()));
             }
             Ok(storage.data.clone())
+        }
+
+        async fn delete_value(&self, _key: &str) -> Result<(), Error> {
+            let mut storage = self.storage.lock().unwrap();
+            storage.data = None;
+            Ok(())
         }
     }
 

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -46,6 +46,13 @@ impl Cache for Backend {
         let value: Option<String> = conn.get(key).await?;
         Ok(value)
     }
+
+    async fn delete_value(&self, key: &str) -> Result<(), Error> {
+        let mut conn = self.get_connection().await?;
+        let key = format!("{}{key}", self.key_prefix);
+        let () = conn.del(key).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/command/scrub/command.rs
+++ b/src/command/scrub/command.rs
@@ -79,8 +79,8 @@ fn build_blob_store(config: &blob_store::BlobStorageConfig) -> Result<Arc<dyn Bl
     Ok(blob_store)
 }
 
-fn build_metadata_store(config: &Configuration) -> Result<Arc<dyn MetadataStore>, Error> {
-    match config.resolve_metadata_config().to_backend(None) {
+async fn build_metadata_store(config: &Configuration) -> Result<Arc<dyn MetadataStore>, Error> {
+    match config.resolve_metadata_config().to_backend(None).await {
         Ok(store) => Ok(store),
         Err(err) => {
             let msg = format!("Failed to initialize metadata store: {err}");
@@ -143,9 +143,9 @@ fn build_global_retention_policy(
 }
 
 impl Command {
-    pub fn new(options: &Options, config: &Configuration) -> Result<Self, Error> {
+    pub async fn new(options: &Options, config: &Configuration) -> Result<Self, Error> {
         let blob_store = build_blob_store(&config.blob_store)?;
-        let metadata_store = build_metadata_store(config)?;
+        let metadata_store = build_metadata_store(config).await?;
         let auth_cache = build_auth_cache(&config.cache)?;
         let repositories = build_repositories(&config.repository, &auth_cache)?;
 
@@ -409,7 +409,7 @@ mod tests {
             media_types: false,
         };
 
-        let command = Command::new(&options, &config);
+        let command = Command::new(&options, &config).await;
 
         assert!(command.is_ok());
         let cmd = command.unwrap();
@@ -467,7 +467,7 @@ mod tests {
             media_types: false,
         };
 
-        let command = Command::new(&options, &config).unwrap();
+        let command = Command::new(&options, &config).await.unwrap();
         let result = command.run().await;
 
         assert!(result.is_ok());

--- a/src/command/server/auth/authorizer.rs
+++ b/src/command/server/auth/authorizer.rs
@@ -682,13 +682,17 @@ mod tests {
         toml::from_str(toml).unwrap()
     }
 
-    fn create_pull_through_registry(config: &Configuration) -> Registry {
+    async fn create_pull_through_registry(config: &Configuration) -> Registry {
         use std::{collections::HashMap, sync::Arc};
 
         use crate::registry::{RegistryConfig, Repository};
 
         let blob_store = config.blob_store.to_backend().unwrap();
-        let metadata_store = config.resolve_metadata_config().to_backend(None).unwrap();
+        let metadata_store = config
+            .resolve_metadata_config()
+            .to_backend(None)
+            .await
+            .unwrap();
         let auth_cache = config.cache.to_backend().unwrap();
 
         let mut repositories_map = HashMap::new();
@@ -717,7 +721,7 @@ mod tests {
         let config = create_pull_through_config();
         let cache = cache::Config::Memory.to_backend().unwrap();
         let authorizer = Authorizer::new(&config, &cache).unwrap();
-        let registry = create_pull_through_registry(&config);
+        let registry = create_pull_through_registry(&config).await;
 
         let namespace = Namespace::new("docker-io/library/nginx").unwrap();
         let reference = Reference::from_str("latest").unwrap();
@@ -751,7 +755,7 @@ mod tests {
         let config = create_pull_through_config();
         let cache = cache::Config::Memory.to_backend().unwrap();
         let authorizer = Authorizer::new(&config, &cache).unwrap();
-        let registry = create_pull_through_registry(&config);
+        let registry = create_pull_through_registry(&config).await;
 
         let namespace = Namespace::new("docker-io/library/nginx").unwrap();
         let digest = Digest::from_str(
@@ -785,7 +789,7 @@ mod tests {
         let config = create_pull_through_config();
         let cache = cache::Config::Memory.to_backend().unwrap();
         let authorizer = Authorizer::new(&config, &cache).unwrap();
-        let registry = create_pull_through_registry(&config);
+        let registry = create_pull_through_registry(&config).await;
 
         let identity = ClientIdentity::new(None);
         let (parts, ()) = hyper::Request::builder()

--- a/src/command/server/command.rs
+++ b/src/command/server/command.rs
@@ -66,7 +66,9 @@ async fn build_metadata_store(
 
     if let MetadataStoreConfig::S3(ref mut backend_config) = metadata_config {
         if backend_config.capabilities.is_none() {
-            let guard = cached_capabilities.lock().expect("capabilities mutex poisoned");
+            let guard = cached_capabilities
+                .lock()
+                .expect("capabilities mutex poisoned");
             if guard.is_some() {
                 backend_config.capabilities = guard.clone();
             }
@@ -75,7 +77,9 @@ async fn build_metadata_store(
 
     match metadata_config.to_backend(Some(cache.clone())).await {
         Ok(store) => {
-            let mut guard = cached_capabilities.lock().expect("capabilities mutex poisoned");
+            let mut guard = cached_capabilities
+                .lock()
+                .expect("capabilities mutex poisoned");
             *guard = store.conditional_capabilities();
             Ok(store)
         }
@@ -555,7 +559,9 @@ mod tests {
             panic!("Expected insecure config")
         };
 
-        let registry = build_registry(&config, &Arc::new(Mutex::new(None))).await.unwrap();
+        let registry = build_registry(&config, &Arc::new(Mutex::new(None)))
+            .await
+            .unwrap();
         let context = ServerContext::new(&config, registry).unwrap();
 
         let insecure_listener = InsecureListener::new(insecure_config, context);
@@ -592,7 +598,10 @@ mod tests {
 
         let blob_store = build_blob_store(&config.blob_store).unwrap();
         let auth_cache = build_auth_cache(&config.cache).unwrap();
-        let metadata_store = build_metadata_store(&config, &auth_cache, &Arc::new(Mutex::new(None))).await.unwrap();
+        let metadata_store =
+            build_metadata_store(&config, &auth_cache, &Arc::new(Mutex::new(None)))
+                .await
+                .unwrap();
         let repositories = build_repositories(&config.repository, &auth_cache).unwrap();
 
         let registry_config = RegistryConfig::new()

--- a/src/command/server/command.rs
+++ b/src/command/server/command.rs
@@ -65,14 +65,15 @@ async fn build_metadata_store(
     let mut metadata_config = config.resolve_metadata_config();
 
     if let MetadataStoreConfig::S3(ref mut backend_config) = metadata_config
-        && backend_config.capabilities.is_none() {
-            let guard = cached_capabilities
-                .lock()
-                .expect("capabilities mutex poisoned");
-            if guard.is_some() {
-                backend_config.capabilities = guard.clone();
-            }
+        && backend_config.capabilities.is_none()
+    {
+        let guard = cached_capabilities
+            .lock()
+            .expect("capabilities mutex poisoned");
+        if guard.is_some() {
+            backend_config.capabilities.clone_from(&guard);
         }
+    }
 
     match metadata_config.to_backend(Some(cache.clone())).await {
         Ok(store) => {

--- a/src/command/server/command.rs
+++ b/src/command/server/command.rs
@@ -1,6 +1,11 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use argh::FromArgs;
+use async_trait::async_trait;
 use tracing::error;
 
 use super::{
@@ -16,8 +21,10 @@ use crate::{
     command::server::error::Error,
     configuration::{Configuration, ServerConfig},
     registry::{
-        Registry, RegistryConfig, Repository, blob_store, blob_store::BlobStore,
-        metadata_store::MetadataStore, repository,
+        Registry, RegistryConfig, Repository, blob_store,
+        blob_store::BlobStore,
+        metadata_store::{ConditionalCapabilities, MetadataStore, MetadataStoreConfig},
+        repository,
     },
     watcher::ConfigNotifier,
 };
@@ -37,6 +44,7 @@ pub struct Options {}
 
 pub struct Command {
     listener: ServiceListener,
+    cached_capabilities: Arc<Mutex<Option<ConditionalCapabilities>>>,
 }
 
 // TODO: deduplicate!
@@ -49,15 +57,28 @@ fn build_blob_store(config: &blob_store::BlobStorageConfig) -> Result<Arc<dyn Bl
     Ok(blob_store)
 }
 
-fn build_metadata_store(
+async fn build_metadata_store(
     config: &Configuration,
     cache: &Arc<dyn Cache>,
+    cached_capabilities: &Arc<Mutex<Option<ConditionalCapabilities>>>,
 ) -> Result<Arc<dyn MetadataStore>, Error> {
-    match config
-        .resolve_metadata_config()
-        .to_backend(Some(cache.clone()))
-    {
-        Ok(store) => Ok(store),
+    let mut metadata_config = config.resolve_metadata_config();
+
+    if let MetadataStoreConfig::S3(ref mut backend_config) = metadata_config {
+        if backend_config.capabilities.is_none() {
+            let guard = cached_capabilities.lock().expect("capabilities mutex poisoned");
+            if guard.is_some() {
+                backend_config.capabilities = guard.clone();
+            }
+        }
+    }
+
+    match metadata_config.to_backend(Some(cache.clone())).await {
+        Ok(store) => {
+            let mut guard = cached_capabilities.lock().expect("capabilities mutex poisoned");
+            *guard = store.conditional_capabilities();
+            Ok(store)
+        }
         Err(err) => {
             let msg = format!("Failed to initialize metadata store: {err}");
             Err(Error::Initialization(msg))
@@ -102,10 +123,13 @@ fn build_repositories(
     Ok(Arc::new(repositories))
 }
 
-fn build_registry(config: &Configuration) -> Result<Registry, Error> {
+async fn build_registry(
+    config: &Configuration,
+    cached_capabilities: &Arc<Mutex<Option<ConditionalCapabilities>>>,
+) -> Result<Registry, Error> {
     let blob_store = build_blob_store(&config.blob_store)?;
     let auth_cache = build_auth_cache(&config.cache)?;
-    let metadata_store = build_metadata_store(config, &auth_cache)?;
+    let metadata_store = build_metadata_store(config, &auth_cache, cached_capabilities).await?;
     let repositories = build_repositories(&config.repository, &auth_cache)?;
 
     let registry_config = RegistryConfig::new()
@@ -125,9 +149,10 @@ fn build_registry(config: &Configuration) -> Result<Registry, Error> {
 }
 
 impl Command {
-    pub fn new(config: &Configuration) -> Result<Command, Error> {
+    pub async fn new(config: &Configuration) -> Result<Command, Error> {
         // TODO: non-overlapping configuration subset (?) for each of those helpers
-        let registry = build_registry(config)?;
+        let cached_capabilities = Arc::new(Mutex::new(None));
+        let registry = build_registry(config, &cached_capabilities).await?;
         let context = ServerContext::new(config, registry)?;
 
         let listener = match &config.server {
@@ -139,11 +164,14 @@ impl Command {
             }
         };
 
-        Ok(Command { listener })
+        Ok(Command {
+            listener,
+            cached_capabilities,
+        })
     }
 
-    pub fn notify_config_change(&self, config: &Configuration) -> Result<(), Error> {
-        let registry = build_registry(config)?;
+    pub async fn notify_config_change(&self, config: &Configuration) -> Result<(), Error> {
+        let registry = build_registry(config, &self.cached_capabilities).await?;
         let context = ServerContext::new(config, registry)?;
 
         match (&self.listener, &config.server) {
@@ -190,9 +218,10 @@ impl Command {
     }
 }
 
+#[async_trait]
 impl ConfigNotifier for Command {
-    fn notify_config_change(&self, config: &Configuration) {
-        if let Err(e) = self.notify_config_change(config) {
+    async fn notify_config_change(&self, config: &Configuration) {
+        if let Err(e) = self.notify_config_change(config).await {
             error!("Failed to apply configuration: {e}");
         }
     }
@@ -265,17 +294,17 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_build_metadata_store_filesystem_success() {
+    #[tokio::test]
+    async fn test_build_metadata_store_filesystem_success() {
         let config = create_minimal_config();
         let auth_cache = build_auth_cache(&config.cache).unwrap();
-        let result = build_metadata_store(&config, &auth_cache);
+        let result = build_metadata_store(&config, &auth_cache, &Arc::new(Mutex::new(None))).await;
 
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_build_metadata_store_with_explicit_config() {
+    #[tokio::test]
+    async fn test_build_metadata_store_with_explicit_config() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test-blobs"
@@ -296,7 +325,7 @@ mod tests {
 
         let config: Configuration = toml::from_str(toml).unwrap();
         let auth_cache = build_auth_cache(&config.cache).unwrap();
-        let result = build_metadata_store(&config, &auth_cache);
+        let result = build_metadata_store(&config, &auth_cache, &Arc::new(Mutex::new(None))).await;
 
         assert!(result.is_ok());
     }
@@ -433,24 +462,24 @@ mod tests {
         assert!(repos.contains_key("repo3"));
     }
 
-    #[test]
-    fn test_build_registry_minimal_config() {
+    #[tokio::test]
+    async fn test_build_registry_minimal_config() {
         let config = create_minimal_config();
-        let result = build_registry(&config);
+        let result = build_registry(&config, &Arc::new(Mutex::new(None))).await;
 
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_build_registry_with_repositories() {
+    #[tokio::test]
+    async fn test_build_registry_with_repositories() {
         let config = create_config_with_repository();
-        let result = build_registry(&config);
+        let result = build_registry(&config, &Arc::new(Mutex::new(None))).await;
 
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_build_registry_with_update_pull_time() {
+    #[tokio::test]
+    async fn test_build_registry_with_update_pull_time() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test-blobs"
@@ -470,15 +499,15 @@ mod tests {
         "#;
 
         let config: Configuration = toml::from_str(toml).unwrap();
-        let result = build_registry(&config);
+        let result = build_registry(&config, &Arc::new(Mutex::new(None))).await;
 
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_command_new_insecure_listener() {
+    #[tokio::test]
+    async fn test_command_new_insecure_listener() {
         let config = create_minimal_config();
-        let result = Command::new(&config);
+        let result = Command::new(&config).await;
 
         assert!(result.is_ok());
         let command = result.unwrap();
@@ -489,29 +518,29 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_command_new_with_repositories() {
+    #[tokio::test]
+    async fn test_command_new_with_repositories() {
         let config = create_config_with_repository();
-        let result = Command::new(&config);
+        let result = Command::new(&config).await;
 
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_command_notify_config_change_insecure() {
+    #[tokio::test]
+    async fn test_command_notify_config_change_insecure() {
         let config = create_minimal_config();
-        let command = Command::new(&config).unwrap();
+        let command = Command::new(&config).await.unwrap();
 
         let new_config = create_minimal_config();
-        let result = command.notify_config_change(&new_config);
+        let result = command.notify_config_change(&new_config).await;
 
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_command_notify_tls_config_change_with_insecure_listener() {
+    #[tokio::test]
+    async fn test_command_notify_tls_config_change_with_insecure_listener() {
         let config = create_minimal_config();
-        let command = Command::new(&config).unwrap();
+        let command = Command::new(&config).await.unwrap();
 
         let (tls_config, _temp_files) = build_config(false);
         let result = command.notify_tls_config_change(&tls_config);
@@ -519,14 +548,14 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_service_listener_enum_variants() {
+    #[tokio::test]
+    async fn test_service_listener_enum_variants() {
         let config = create_minimal_config();
         let ServerConfig::Insecure(insecure_config) = &config.server else {
             panic!("Expected insecure config")
         };
 
-        let registry = build_registry(&config).unwrap();
+        let registry = build_registry(&config, &Arc::new(Mutex::new(None))).await.unwrap();
         let context = ServerContext::new(&config, registry).unwrap();
 
         let insecure_listener = InsecureListener::new(insecure_config, context);
@@ -557,13 +586,13 @@ mod tests {
         assert!(repos.get("delta").is_none());
     }
 
-    #[test]
-    fn test_build_registry_components_integration() {
+    #[tokio::test]
+    async fn test_build_registry_components_integration() {
         let config = create_config_with_repository();
 
         let blob_store = build_blob_store(&config.blob_store).unwrap();
         let auth_cache = build_auth_cache(&config.cache).unwrap();
-        let metadata_store = build_metadata_store(&config, &auth_cache).unwrap();
+        let metadata_store = build_metadata_store(&config, &auth_cache, &Arc::new(Mutex::new(None))).await.unwrap();
         let repositories = build_repositories(&config.repository, &auth_cache).unwrap();
 
         let registry_config = RegistryConfig::new()
@@ -578,10 +607,10 @@ mod tests {
         assert!(registry.is_ok());
     }
 
-    #[test]
-    fn test_command_new_validates_configuration() {
+    #[tokio::test]
+    async fn test_command_new_validates_configuration() {
         let config = create_minimal_config();
-        let result = Command::new(&config);
+        let result = Command::new(&config).await;
 
         assert!(result.is_ok());
     }
@@ -698,10 +727,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_hot_reload_adds_webhook_via_command() {
+    #[tokio::test]
+    async fn test_hot_reload_adds_webhook_via_command() {
         let config = create_minimal_config();
-        let command = Command::new(&config).unwrap();
+        let command = Command::new(&config).await.unwrap();
 
         assert!(
             command
@@ -712,7 +741,7 @@ mod tests {
         );
 
         let new_config = create_config_with_webhook("https://example.com/webhook");
-        command.notify_config_change(&new_config).unwrap();
+        command.notify_config_change(&new_config).await.unwrap();
 
         assert!(
             command
@@ -723,10 +752,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_hot_reload_removes_webhook_via_command() {
+    #[tokio::test]
+    async fn test_hot_reload_removes_webhook_via_command() {
         let config = create_config_with_webhook("https://example.com/webhook");
-        let command = Command::new(&config).unwrap();
+        let command = Command::new(&config).await.unwrap();
 
         assert!(
             command
@@ -737,7 +766,7 @@ mod tests {
         );
 
         let new_config = create_minimal_config();
-        command.notify_config_change(&new_config).unwrap();
+        command.notify_config_change(&new_config).await.unwrap();
 
         assert!(
             command
@@ -773,10 +802,10 @@ mod tests {
             .await;
 
         let config_a = create_config_with_webhook(&format!("{}/webhook", server_a.uri()));
-        let command = Command::new(&config_a).unwrap();
+        let command = Command::new(&config_a).await.unwrap();
 
         let config_b = create_config_with_webhook(&format!("{}/webhook", server_b.uri()));
-        command.notify_config_change(&config_b).unwrap();
+        command.notify_config_change(&config_b).await.unwrap();
 
         let context = command.insecure_listener().current_context();
         context.dispatch_event(&create_test_event()).await.unwrap();
@@ -802,10 +831,10 @@ mod tests {
             .await;
 
         let config_one = create_config_with_webhook(&server_a.uri());
-        let command = Command::new(&config_one).unwrap();
+        let command = Command::new(&config_one).await.unwrap();
 
         let config_two = create_config_with_two_webhooks(&server_a.uri(), &server_b.uri());
-        command.notify_config_change(&config_two).unwrap();
+        command.notify_config_change(&config_two).await.unwrap();
 
         let context = command.insecure_listener().current_context();
         context.dispatch_event(&create_test_event()).await.unwrap();
@@ -831,10 +860,10 @@ mod tests {
             .await;
 
         let config_two = create_config_with_two_webhooks(&server_a.uri(), &server_b.uri());
-        let command = Command::new(&config_two).unwrap();
+        let command = Command::new(&config_two).await.unwrap();
 
         let config_one = create_config_with_webhook(&server_a.uri());
-        command.notify_config_change(&config_one).unwrap();
+        command.notify_config_change(&config_one).await.unwrap();
 
         let context = command.insecure_listener().current_context();
         context.dispatch_event(&create_test_event()).await.unwrap();
@@ -860,12 +889,12 @@ mod tests {
             .await;
 
         let config_old = create_config_with_webhook(&server_old.uri());
-        let command = Command::new(&config_old).unwrap();
+        let command = Command::new(&config_old).await.unwrap();
 
         let old_context = Arc::clone(&command.insecure_listener().current_context());
 
         let config_new = create_config_with_webhook(&server_new.uri());
-        command.notify_config_change(&config_new).unwrap();
+        command.notify_config_change(&config_new).await.unwrap();
 
         old_context
             .dispatch_event(&create_test_event())
@@ -923,7 +952,7 @@ mod tests {
             .await;
 
         let valid_config = create_config_with_webhook(&server.uri());
-        let command = Command::new(&valid_config).unwrap();
+        let command = Command::new(&valid_config).await.unwrap();
 
         assert!(
             command
@@ -934,7 +963,7 @@ mod tests {
         );
 
         let invalid_config = create_invalid_cache_config_with_webhook("https://other.example.com");
-        let result = command.notify_config_change(&invalid_config);
+        let result = command.notify_config_change(&invalid_config).await;
         assert!(result.is_err());
 
         assert!(
@@ -969,27 +998,27 @@ mod tests {
             .await;
 
         let config_a = create_config_with_webhook(&server_a.uri());
-        let command = Command::new(&config_a).unwrap();
+        let command = Command::new(&config_a).await.unwrap();
 
         let invalid_config = create_invalid_cache_config_with_webhook("https://bad.example.com");
-        let result = command.notify_config_change(&invalid_config);
+        let result = command.notify_config_change(&invalid_config).await;
         assert!(result.is_err());
 
         let config_b = create_config_with_webhook(&server_b.uri());
-        command.notify_config_change(&config_b).unwrap();
+        command.notify_config_change(&config_b).await.unwrap();
 
         let context = command.insecure_listener().current_context();
         context.dispatch_event(&create_test_event()).await.unwrap();
     }
 
-    #[test]
-    fn test_config_notifier_trait_handles_reload_error_gracefully() {
+    #[tokio::test]
+    async fn test_config_notifier_trait_handles_reload_error_gracefully() {
         let valid_config = create_minimal_config();
-        let command = Command::new(&valid_config).unwrap();
+        let command = Command::new(&valid_config).await.unwrap();
 
         let invalid_config = create_invalid_cache_config_with_webhook("https://example.com");
 
-        ConfigNotifier::notify_config_change(&command, &invalid_config);
+        ConfigNotifier::notify_config_change(&command, &invalid_config).await;
 
         assert!(
             command
@@ -1004,7 +1033,7 @@ mod tests {
     async fn test_command_shutdown_with_no_dispatcher() {
         // Command with no webhooks should shut down cleanly
         let config = create_minimal_config();
-        let command = Command::new(&config).unwrap();
+        let command = Command::new(&config).await.unwrap();
 
         // shutdown() must exist on Command and complete without panic
         command.shutdown_with_timeout(Duration::from_secs(10)).await;
@@ -1026,7 +1055,7 @@ mod tests {
             .await;
 
         let config = create_config_with_webhook(&server.uri());
-        let command = Command::new(&config).unwrap();
+        let command = Command::new(&config).await.unwrap();
 
         // Dispatch an async event through the current context
         let context = command.insecure_listener().current_context();

--- a/src/command/server/command.rs
+++ b/src/command/server/command.rs
@@ -64,8 +64,8 @@ async fn build_metadata_store(
 ) -> Result<Arc<dyn MetadataStore>, Error> {
     let mut metadata_config = config.resolve_metadata_config();
 
-    if let MetadataStoreConfig::S3(ref mut backend_config) = metadata_config {
-        if backend_config.capabilities.is_none() {
+    if let MetadataStoreConfig::S3(ref mut backend_config) = metadata_config
+        && backend_config.capabilities.is_none() {
             let guard = cached_capabilities
                 .lock()
                 .expect("capabilities mutex poisoned");
@@ -73,7 +73,6 @@ async fn build_metadata_store(
                 backend_config.capabilities = guard.clone();
             }
         }
-    }
 
     match metadata_config.to_backend(Some(cache.clone())).await {
         Ok(store) => {

--- a/src/command/server/http_server.rs
+++ b/src/command/server/http_server.rs
@@ -16,6 +16,7 @@ use hyper::{
 };
 use hyper_util::rt::TokioIo;
 use opentelemetry::trace::TraceContextExt;
+use serde::Serialize;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     pin,
@@ -23,8 +24,6 @@ use tokio::{
 use tracing::{Span, debug, error, info, instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
-
-use serde::Serialize;
 
 use crate::{
     command::server::{
@@ -673,8 +672,9 @@ async fn handle_readyz(
                 status: "ready",
                 conditional: if verbose { conditional.as_ref() } else { None },
             };
-            let body = serde_json::to_string(&payload)
-                .map_err(|e| Error::Internal(format!("Failed to serialize readyz response: {e}")))?;
+            let body = serde_json::to_string(&payload).map_err(|e| {
+                Error::Internal(format!("Failed to serialize readyz response: {e}"))
+            })?;
             Response::builder()
                 .status(StatusCode::OK)
                 .header(CONTENT_TYPE, "application/json")
@@ -686,8 +686,9 @@ async fn handle_readyz(
                 status: "not_ready",
                 error: e.to_string(),
             };
-            let body = serde_json::to_string(&payload)
-                .map_err(|e| Error::Internal(format!("Failed to serialize readyz response: {e}")))?;
+            let body = serde_json::to_string(&payload).map_err(|e| {
+                Error::Internal(format!("Failed to serialize readyz response: {e}"))
+            })?;
             Response::builder()
                 .status(StatusCode::SERVICE_UNAVAILABLE)
                 .header(CONTENT_TYPE, "application/json")

--- a/src/command/server/http_server.rs
+++ b/src/command/server/http_server.rs
@@ -249,6 +249,7 @@ async fn dispatch_route<'a>(
             handle_list_namespaces(context, repository, identity).await
         }
         Route::Healthz => handle_healthz(),
+        Route::Readyz => handle_readyz(context).await,
         Route::Metrics => handle_metrics(),
     }
 }
@@ -638,6 +639,26 @@ fn handle_healthz() -> Result<Response<ResponseBody>, Error> {
             let msg = format!("Failed to build healthz response: {e}");
             Err(Error::Internal(msg))
         }
+    }
+}
+
+async fn handle_readyz(context: &ServerContext) -> Result<Response<ResponseBody>, Error> {
+    match context.registry.check_ready().await {
+        Ok(()) => Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "application/json")
+            .body(ResponseBody::Fixed(Full::new(Bytes::from(
+                r#"{"status":"ready"}"#,
+            ))))
+            .map_err(|e| Error::Internal(format!("Failed to build readyz response: {e}"))),
+        Err(e) => Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .header(CONTENT_TYPE, "application/json")
+            .body(ResponseBody::Fixed(Full::new(Bytes::from(format!(
+                r#"{{"status":"not_ready","error":"{}"}}"#,
+                e.to_string().replace('"', "\\\"")
+            )))))
+            .map_err(|e| Error::Internal(format!("Failed to build readyz response: {e}"))),
     }
 }
 

--- a/src/command/server/http_server.rs
+++ b/src/command/server/http_server.rs
@@ -24,6 +24,8 @@ use tracing::{Span, debug, error, info, instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
+use serde::Serialize;
+
 use crate::{
     command::server::{
         ServerContext,
@@ -37,6 +39,7 @@ use crate::{
     identity::{ClientIdentity, Route},
     metrics_provider::{IN_FLIGHT_REQUESTS, METRICS_PROVIDER},
     oci::{Digest, Namespace, Reference},
+    registry::metadata_store::ConditionalCapabilities,
 };
 
 pub async fn serve_request<S>(
@@ -249,7 +252,7 @@ async fn dispatch_route<'a>(
             handle_list_namespaces(context, repository, identity).await
         }
         Route::Healthz => handle_healthz(),
-        Route::Readyz => handle_readyz(context).await,
+        Route::Readyz => handle_readyz(context, parts).await,
         Route::Metrics => handle_metrics(),
     }
 }
@@ -642,23 +645,55 @@ fn handle_healthz() -> Result<Response<ResponseBody>, Error> {
     }
 }
 
-async fn handle_readyz(context: &ServerContext) -> Result<Response<ResponseBody>, Error> {
+async fn handle_readyz(
+    context: &ServerContext,
+    parts: &hyper::http::request::Parts,
+) -> Result<Response<ResponseBody>, Error> {
+    #[derive(Serialize)]
+    struct ReadyResponse<'a> {
+        status: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        conditional: Option<&'a ConditionalCapabilities>,
+    }
+
+    #[derive(Serialize)]
+    struct NotReadyResponse {
+        status: &'static str,
+        error: String,
+    }
+
+    let verbose = parts
+        .uri
+        .query()
+        .is_some_and(|q| q.contains("verbose=true"));
+
     match context.registry.check_ready().await {
-        Ok(()) => Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, "application/json")
-            .body(ResponseBody::Fixed(Full::new(Bytes::from(
-                r#"{"status":"ready"}"#,
-            ))))
-            .map_err(|e| Error::Internal(format!("Failed to build readyz response: {e}"))),
-        Err(e) => Response::builder()
-            .status(StatusCode::SERVICE_UNAVAILABLE)
-            .header(CONTENT_TYPE, "application/json")
-            .body(ResponseBody::Fixed(Full::new(Bytes::from(format!(
-                r#"{{"status":"not_ready","error":"{}"}}"#,
-                e.to_string().replace('"', "\\\"")
-            )))))
-            .map_err(|e| Error::Internal(format!("Failed to build readyz response: {e}"))),
+        Ok(conditional) => {
+            let payload = ReadyResponse {
+                status: "ready",
+                conditional: if verbose { conditional.as_ref() } else { None },
+            };
+            let body = serde_json::to_string(&payload)
+                .map_err(|e| Error::Internal(format!("Failed to serialize readyz response: {e}")))?;
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/json")
+                .body(ResponseBody::Fixed(Full::new(Bytes::from(body))))
+                .map_err(|e| Error::Internal(format!("Failed to build readyz response: {e}")))
+        }
+        Err(e) => {
+            let payload = NotReadyResponse {
+                status: "not_ready",
+                error: e.to_string(),
+            };
+            let body = serde_json::to_string(&payload)
+                .map_err(|e| Error::Internal(format!("Failed to serialize readyz response: {e}")))?;
+            Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .header(CONTENT_TYPE, "application/json")
+                .body(ResponseBody::Fixed(Full::new(Bytes::from(body))))
+                .map_err(|e| Error::Internal(format!("Failed to build readyz response: {e}")))
+        }
     }
 }
 
@@ -1119,7 +1154,11 @@ mod tests {
 
         let config: Configuration = toml::from_str(toml).unwrap();
         let blob_store = config.blob_store.to_backend().unwrap();
-        let metadata_store = config.resolve_metadata_config().to_backend(None).unwrap();
+        let metadata_store = config
+            .resolve_metadata_config()
+            .to_backend(None)
+            .await
+            .unwrap();
         let repositories = Arc::new(HashMap::new());
         let registry_config = RegistryConfig::new()
             .update_pull_time(false)
@@ -1141,7 +1180,7 @@ mod tests {
         assert!(identity.username.is_none());
     }
 
-    fn create_test_context_with_allow_policy() -> ServerContext {
+    async fn create_test_context_with_allow_policy() -> ServerContext {
         use std::collections::HashMap;
 
         use crate::{
@@ -1173,7 +1212,11 @@ mod tests {
 
         let config: Configuration = toml::from_str(toml).unwrap();
         let blob_store = config.blob_store.to_backend().unwrap();
-        let metadata_store = config.resolve_metadata_config().to_backend(None).unwrap();
+        let metadata_store = config
+            .resolve_metadata_config()
+            .to_backend(None)
+            .await
+            .unwrap();
         let repositories = Arc::new(HashMap::new());
         let registry_config = RegistryConfig::new()
             .update_pull_time(false)
@@ -1190,7 +1233,7 @@ mod tests {
     async fn test_handle_list_repositories_accepts_identity() {
         use crate::identity::ClientIdentity;
 
-        let context = create_test_context_with_allow_policy();
+        let context = create_test_context_with_allow_policy().await;
         let identity = ClientIdentity::default();
 
         let result = handle_list_repositories(&context, &identity).await;
@@ -1202,7 +1245,7 @@ mod tests {
     async fn test_handle_list_catalog_accepts_identity() {
         use crate::identity::ClientIdentity;
 
-        let context = create_test_context_with_allow_policy();
+        let context = create_test_context_with_allow_policy().await;
         let identity = ClientIdentity::default();
 
         let result = handle_list_catalog(&context, None, None, &identity).await;
@@ -1214,7 +1257,7 @@ mod tests {
     async fn test_handle_delete_blob_accepts_identity() {
         use crate::identity::ClientIdentity;
 
-        let context = create_test_context_with_allow_policy();
+        let context = create_test_context_with_allow_policy().await;
         let identity = ClientIdentity::default();
         let namespace = Namespace::new("test/repo").unwrap();
         let digest: Digest =

--- a/src/command/server/listeners/insecure.rs
+++ b/src/command/server/listeners/insecure.rs
@@ -186,8 +186,8 @@ mod tests {
         assert_eq!(config.port, 8443);
     }
 
-    #[test]
-    fn test_insecure_listener_new() {
+    #[tokio::test]
+    async fn test_insecure_listener_new() {
         let config = Config {
             bind_address: "127.0.0.1".parse().unwrap(),
             port: 8080,
@@ -195,7 +195,7 @@ mod tests {
             query_timeout_grace_period: 30,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let listener = InsecureListener::new(&config, context);
 
         assert_eq!(
@@ -204,8 +204,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_insecure_listener_new_with_ipv6() {
+    #[tokio::test]
+    async fn test_insecure_listener_new_with_ipv6() {
         let config = Config {
             bind_address: "::1".parse().unwrap(),
             port: 9000,
@@ -213,7 +213,7 @@ mod tests {
             query_timeout_grace_period: 60,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let listener = InsecureListener::new(&config, context);
 
         assert_eq!(
@@ -223,18 +223,18 @@ mod tests {
         assert_eq!(listener.binding_address.port(), 9000);
     }
 
-    #[test]
-    fn test_insecure_listener_notify_config_change() {
+    #[tokio::test]
+    async fn test_insecure_listener_notify_config_change() {
         let config = Config::default();
-        let context1 = create_test_server_context();
+        let context1 = create_test_server_context().await;
         let listener = InsecureListener::new(&config, context1);
 
-        let context2 = create_test_server_context();
+        let context2 = create_test_server_context().await;
         listener.notify_config_change(context2);
     }
 
-    #[test]
-    fn test_insecure_listener_timeouts_initialization() {
+    #[tokio::test]
+    async fn test_insecure_listener_timeouts_initialization() {
         let config = Config {
             bind_address: "127.0.0.1".parse().unwrap(),
             port: 8080,
@@ -242,7 +242,7 @@ mod tests {
             query_timeout_grace_period: 100,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let listener = InsecureListener::new(&config, context);
 
         let timeouts = listener.timeouts.load();
@@ -250,8 +250,8 @@ mod tests {
         assert_eq!(timeouts[1], Duration::from_secs(100));
     }
 
-    #[test]
-    fn test_insecure_listener_with_zero_port() {
+    #[tokio::test]
+    async fn test_insecure_listener_with_zero_port() {
         let config = Config {
             bind_address: "127.0.0.1".parse().unwrap(),
             port: 0,
@@ -259,20 +259,20 @@ mod tests {
             query_timeout_grace_period: 60,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let listener = InsecureListener::new(&config, context);
 
         assert_eq!(listener.binding_address.port(), 0);
     }
 
-    #[test]
-    fn test_insecure_listener_multiple_config_changes() {
+    #[tokio::test]
+    async fn test_insecure_listener_multiple_config_changes() {
         let config = Config::default();
-        let context1 = create_test_server_context();
+        let context1 = create_test_server_context().await;
         let listener = InsecureListener::new(&config, context1);
 
         for _ in 0..5 {
-            let context = create_test_server_context();
+            let context = create_test_server_context().await;
             listener.notify_config_change(context);
         }
     }
@@ -306,9 +306,13 @@ mod tests {
         toml::from_str(&toml).unwrap()
     }
 
-    fn create_server_context_from_config(config: &Configuration) -> ServerContext {
+    async fn create_server_context_from_config(config: &Configuration) -> ServerContext {
         let blob_store = config.blob_store.to_backend().unwrap();
-        let metadata_store = config.resolve_metadata_config().to_backend(None).unwrap();
+        let metadata_store = config
+            .resolve_metadata_config()
+            .to_backend(None)
+            .await
+            .unwrap();
         let repositories = Arc::new(HashMap::new());
 
         let registry_config = RegistryConfig::new()
@@ -338,31 +342,31 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_hot_reload_updates_webhook_config() {
+    #[tokio::test]
+    async fn test_hot_reload_updates_webhook_config() {
         let listener_config = Config::default();
-        let context_without_webhooks = create_test_server_context();
+        let context_without_webhooks = create_test_server_context().await;
         let listener = InsecureListener::new(&listener_config, context_without_webhooks);
 
         assert!(listener.current_context().event_dispatcher().is_none());
 
         let config_with_webhook = create_config_with_webhook("https://example.com/webhook");
-        let context_with_webhooks = create_server_context_from_config(&config_with_webhook);
+        let context_with_webhooks = create_server_context_from_config(&config_with_webhook).await;
         listener.notify_config_change(context_with_webhooks);
 
         assert!(listener.current_context().event_dispatcher().is_some());
     }
 
-    #[test]
-    fn test_hot_reload_removes_webhooks() {
+    #[tokio::test]
+    async fn test_hot_reload_removes_webhooks() {
         let listener_config = Config::default();
         let config_with_webhook = create_config_with_webhook("https://example.com/webhook");
-        let context_with_webhooks = create_server_context_from_config(&config_with_webhook);
+        let context_with_webhooks = create_server_context_from_config(&config_with_webhook).await;
         let listener = InsecureListener::new(&listener_config, context_with_webhooks);
 
         assert!(listener.current_context().event_dispatcher().is_some());
 
-        let context_without_webhooks = create_test_server_context();
+        let context_without_webhooks = create_test_server_context().await;
         listener.notify_config_change(context_without_webhooks);
 
         assert!(listener.current_context().event_dispatcher().is_none());
@@ -389,11 +393,11 @@ mod tests {
 
         let listener_config = Config::default();
         let config_a = create_config_with_webhook(&format!("{}/webhook", server_a.uri()));
-        let context_a = create_server_context_from_config(&config_a);
+        let context_a = create_server_context_from_config(&config_a).await;
         let listener = InsecureListener::new(&listener_config, context_a);
 
         let config_b = create_config_with_webhook(&format!("{}/webhook", server_b.uri()));
-        let context_b = create_server_context_from_config(&config_b);
+        let context_b = create_server_context_from_config(&config_b).await;
         listener.notify_config_change(context_b);
 
         let current_context = listener.current_context();
@@ -454,11 +458,11 @@ mod tests {
 
         let listener_config = Config::default();
         let config_one = create_config_with_webhook(&server_a.uri());
-        let context_one = create_server_context_from_config(&config_one);
+        let context_one = create_server_context_from_config(&config_one).await;
         let listener = InsecureListener::new(&listener_config, context_one);
 
         let config_two = create_config_with_two_webhooks(&server_a.uri(), &server_b.uri());
-        let context_two = create_server_context_from_config(&config_two);
+        let context_two = create_server_context_from_config(&config_two).await;
         listener.notify_config_change(context_two);
 
         let context = listener.current_context();
@@ -484,11 +488,11 @@ mod tests {
 
         let listener_config = Config::default();
         let config_two = create_config_with_two_webhooks(&server_a.uri(), &server_b.uri());
-        let context_two = create_server_context_from_config(&config_two);
+        let context_two = create_server_context_from_config(&config_two).await;
         let listener = InsecureListener::new(&listener_config, context_two);
 
         let config_one = create_config_with_webhook(&server_b.uri());
-        let context_one = create_server_context_from_config(&config_one);
+        let context_one = create_server_context_from_config(&config_one).await;
         listener.notify_config_change(context_one);
 
         let context = listener.current_context();
@@ -514,13 +518,13 @@ mod tests {
 
         let listener_config = Config::default();
         let config_old = create_config_with_webhook(&server_old.uri());
-        let context_old = create_server_context_from_config(&config_old);
+        let context_old = create_server_context_from_config(&config_old).await;
         let listener = InsecureListener::new(&listener_config, context_old);
 
         let old_context = Arc::clone(&listener.current_context());
 
         let config_new = create_config_with_webhook(&server_new.uri());
-        let context_new = create_server_context_from_config(&config_new);
+        let context_new = create_server_context_from_config(&config_new).await;
         listener.notify_config_change(context_new);
 
         old_context
@@ -529,11 +533,11 @@ mod tests {
             .unwrap();
     }
 
-    #[test]
-    fn test_hot_reload_invalid_webhook_config_preserves_old_context() {
+    #[tokio::test]
+    async fn test_hot_reload_invalid_webhook_config_preserves_old_context() {
         let listener_config = Config::default();
         let config_valid = create_config_with_webhook("https://example.com/webhook");
-        let context_valid = create_server_context_from_config(&config_valid);
+        let context_valid = create_server_context_from_config(&config_valid).await;
         let listener = InsecureListener::new(&listener_config, context_valid);
 
         assert!(listener.current_context().event_dispatcher().is_some());
@@ -568,6 +572,7 @@ mod tests {
         let metadata_store = invalid_config
             .resolve_metadata_config()
             .to_backend(None)
+            .await
             .unwrap();
         let repositories = Arc::new(HashMap::new());
 

--- a/src/command/server/listeners/tls.rs
+++ b/src/command/server/listeners/tls.rs
@@ -488,8 +488,8 @@ PpGhlTQXVV6Evtahtp+cRw==
         }
     }
 
-    #[test]
-    fn test_tls_listener_new() {
+    #[tokio::test]
+    async fn test_tls_listener_new() {
         init_crypto_provider();
 
         let (tls, _temp_files) = build_config(false);
@@ -502,7 +502,7 @@ PpGhlTQXVV6Evtahtp+cRw==
             tls,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let result = TlsListener::new(&config, context);
 
         assert!(result.is_ok());
@@ -513,8 +513,8 @@ PpGhlTQXVV6Evtahtp+cRw==
         );
     }
 
-    #[test]
-    fn test_tls_listener_new_with_ipv6() {
+    #[tokio::test]
+    async fn test_tls_listener_new_with_ipv6() {
         init_crypto_provider();
         let (tls, _temp_files) = build_config(false);
 
@@ -526,7 +526,7 @@ PpGhlTQXVV6Evtahtp+cRw==
             tls,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let result = TlsListener::new(&config, context);
 
         assert!(result.is_ok());
@@ -538,8 +538,8 @@ PpGhlTQXVV6Evtahtp+cRw==
         assert_eq!(listener.binding_address.port(), 9443);
     }
 
-    #[test]
-    fn test_tls_listener_new_with_invalid_certs() {
+    #[tokio::test]
+    async fn test_tls_listener_new_with_invalid_certs() {
         init_crypto_provider();
         let cert_file = create_temp_cert_file("invalid");
         let key_file = create_temp_cert_file("invalid");
@@ -556,14 +556,14 @@ PpGhlTQXVV6Evtahtp+cRw==
             tls,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let result = TlsListener::new(&config, context);
 
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_tls_listener_notify_config_change() {
+    #[tokio::test]
+    async fn test_tls_listener_notify_config_change() {
         init_crypto_provider();
         let (tls, _temp_files) = build_config(false);
 
@@ -575,17 +575,17 @@ PpGhlTQXVV6Evtahtp+cRw==
             tls,
         };
 
-        let context1 = create_test_server_context();
+        let context1 = create_test_server_context().await;
         let listener = TlsListener::new(&config, context1).unwrap();
 
-        let context2 = create_test_server_context();
+        let context2 = create_test_server_context().await;
         let result = listener.notify_config_change(&config, context2);
 
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_tls_listener_notify_tls_config_change() {
+    #[tokio::test]
+    async fn test_tls_listener_notify_tls_config_change() {
         init_crypto_provider();
         let (tls, _temp_files) = build_config(false);
 
@@ -597,7 +597,7 @@ PpGhlTQXVV6Evtahtp+cRw==
             tls,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let listener = TlsListener::new(&config, context).unwrap();
 
         let (tls, _temp_files) = build_config(false);
@@ -606,8 +606,8 @@ PpGhlTQXVV6Evtahtp+cRw==
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_tls_listener_notify_tls_config_change_with_invalid_certs() {
+    #[tokio::test]
+    async fn test_tls_listener_notify_tls_config_change_with_invalid_certs() {
         init_crypto_provider();
 
         let (tls, _temp_files) = build_config(false);
@@ -619,7 +619,7 @@ PpGhlTQXVV6Evtahtp+cRw==
             tls,
         };
 
-        let context = create_test_server_context();
+        let context = create_test_server_context().await;
         let listener = TlsListener::new(&config, context).unwrap();
 
         let (mut tls_config, _tmp_files) = build_config(true);

--- a/src/command/server/router.rs
+++ b/src/command/server/router.rs
@@ -19,6 +19,7 @@ pub fn parse<'a>(method: &Method, uri: &'a Uri) -> Route<'a> {
 
     match path {
         "/healthz" if method == Method::GET => return Route::Healthz,
+        "/readyz" if method == Method::GET => return Route::Readyz,
         "/metrics" if method == Method::GET => return Route::Metrics,
         "/_ui/config" if method == Method::GET => return Route::UiConfig,
         "/v2" | "/v2/" if method == Method::GET => return Route::ApiVersion,

--- a/src/command/server/server_context.rs
+++ b/src/command/server/server_context.rs
@@ -1041,7 +1041,7 @@ pub mod tests {
             bucket: "registry".to_string(),
             region: "region".to_string(),
             key_prefix: unique_prefix.clone(),
-            redis: None,
+            lock_strategy: crate::registry::metadata_store::LockStrategy::Memory,
             link_cache_ttl: 0, // disable link cache so reads go to S3
             access_time_debounce_secs: 3600,
         };

--- a/src/command/server/server_context.rs
+++ b/src/command/server/server_context.rs
@@ -160,10 +160,14 @@ pub mod tests {
         toml::from_str(toml).unwrap()
     }
 
-    pub fn create_test_server_context() -> ServerContext {
+    pub async fn create_test_server_context() -> ServerContext {
         let config = create_test_config();
         let blob_store = config.blob_store.to_backend().unwrap();
-        let metadata_store = config.resolve_metadata_config().to_backend(None).unwrap();
+        let metadata_store = config
+            .resolve_metadata_config()
+            .to_backend(None)
+            .await
+            .unwrap();
         let repositories = Arc::new(HashMap::new());
 
         let registry_config = RegistryConfig::new()
@@ -201,9 +205,13 @@ pub mod tests {
         toml::from_str(toml).unwrap()
     }
 
-    fn create_test_registry(config: &Configuration) -> Registry {
+    async fn create_test_registry(config: &Configuration) -> Registry {
         let blob_store = config.blob_store.to_backend().unwrap();
-        let metadata_store = config.resolve_metadata_config().to_backend(None).unwrap();
+        let metadata_store = config
+            .resolve_metadata_config()
+            .to_backend(None)
+            .await
+            .unwrap();
         let auth_cache = config.cache.to_backend().unwrap();
 
         let mut repositories_map = HashMap::new();
@@ -223,18 +231,18 @@ pub mod tests {
         Registry::new(blob_store, metadata_store, repositories, registry_config).unwrap()
     }
 
-    #[test]
-    fn test_server_context_new_minimal() {
+    #[tokio::test]
+    async fn test_server_context_new_minimal() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
 
         let context = ServerContext::new(&config, registry);
 
         assert!(context.is_ok());
     }
 
-    #[test]
-    fn test_server_context_new_with_basic_auth() {
+    #[tokio::test]
+    async fn test_server_context_new_with_basic_auth() {
         let salt = SaltString::generate(OsRng);
         let argon_config = Params::default();
         let argon = Argon2::new(Algorithm::Argon2id, Version::V0x13, argon_config);
@@ -265,15 +273,15 @@ pub mod tests {
         );
 
         let config: Configuration = toml::from_str(&toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
 
         let context = ServerContext::new(&config, registry);
 
         assert!(context.is_ok());
     }
 
-    #[test]
-    fn test_server_context_new_with_global_immutable_tags() {
+    #[tokio::test]
+    async fn test_server_context_new_with_global_immutable_tags() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test"
@@ -295,7 +303,7 @@ pub mod tests {
         "#;
 
         let config: Configuration = toml::from_str(toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
 
         let context = ServerContext::new(&config, registry);
 
@@ -305,7 +313,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_authenticate_request_no_credentials() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let request = Request::builder().body(()).unwrap();
@@ -350,7 +358,7 @@ pub mod tests {
         );
 
         let config: Configuration = toml::from_str(&toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let auth_header = format!(
@@ -374,7 +382,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_authenticate_request_with_x_forwarded_for() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let request = Request::builder()
@@ -393,7 +401,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_authenticate_request_with_x_forwarded_for_single_ip() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let request = Request::builder()
@@ -412,7 +420,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_authenticate_request_with_x_forwarded_for_whitespace() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let request = Request::builder()
@@ -431,7 +439,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_authenticate_request_with_x_real_ip() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let request = Request::builder()
@@ -450,7 +458,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_authenticate_request_x_forwarded_for_takes_precedence() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let request = Request::builder()
@@ -470,7 +478,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_authenticate_request_with_remote_address() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let request = Request::builder().body(()).unwrap();
@@ -489,7 +497,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_authenticate_request_x_forwarded_for_overrides_remote_address() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let request = Request::builder()
@@ -540,7 +548,7 @@ pub mod tests {
         "#;
 
         let config: Configuration = toml::from_str(toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let route = Route::GetManifest {
@@ -556,8 +564,8 @@ pub mod tests {
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_is_tag_immutable_with_global_setting() {
+    #[tokio::test]
+    async fn test_is_tag_immutable_with_global_setting() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test"
@@ -578,14 +586,14 @@ pub mod tests {
         "#;
 
         let config: Configuration = toml::from_str(toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         assert!(context.is_tag_immutable("test/repo", "v1.0.0"));
     }
 
-    #[test]
-    fn test_is_tag_immutable_with_exclusions() {
+    #[tokio::test]
+    async fn test_is_tag_immutable_with_exclusions() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test"
@@ -607,7 +615,7 @@ pub mod tests {
         "#;
 
         let config: Configuration = toml::from_str(toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         assert!(!context.is_tag_immutable("test/repo", "latest"));
@@ -615,8 +623,8 @@ pub mod tests {
         assert!(context.is_tag_immutable("test/repo", "v1.0.0"));
     }
 
-    #[test]
-    fn test_is_tag_immutable_with_repository_override() {
+    #[tokio::test]
+    async fn test_is_tag_immutable_with_repository_override() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test"
@@ -642,7 +650,7 @@ pub mod tests {
         "#;
 
         let config: Configuration = toml::from_str(toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         assert!(context.is_tag_immutable("myrepo", "v1.0.0"));
@@ -650,8 +658,8 @@ pub mod tests {
         assert!(!context.is_tag_immutable("other/repo", "v1.0.0"));
     }
 
-    #[test]
-    fn test_server_context_new_with_event_webhooks() {
+    #[tokio::test]
+    async fn test_server_context_new_with_event_webhooks() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test"
@@ -676,23 +684,23 @@ pub mod tests {
         "#;
 
         let config: Configuration = toml::from_str(toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         assert!(context.event_dispatcher().is_some());
     }
 
-    #[test]
-    fn test_server_context_new_without_event_webhooks() {
+    #[tokio::test]
+    async fn test_server_context_new_without_event_webhooks() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         assert!(context.event_dispatcher().is_none());
     }
 
-    #[test]
-    fn test_server_context_event_dispatcher_is_arc_cloneable() {
+    #[tokio::test]
+    async fn test_server_context_event_dispatcher_is_arc_cloneable() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test"
@@ -717,7 +725,7 @@ pub mod tests {
         "#;
 
         let config: Configuration = toml::from_str(toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let dispatcher: Arc<EventDispatcher> = context.event_dispatcher().unwrap();
@@ -728,7 +736,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_dispatch_event_with_no_dispatcher() {
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let event = Event {
@@ -784,7 +792,7 @@ pub mod tests {
         );
 
         let config: Configuration = toml::from_str(&toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let event = Event {
@@ -839,7 +847,7 @@ pub mod tests {
         );
 
         let config: Configuration = toml::from_str(&toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let event = Event {
@@ -862,7 +870,7 @@ pub mod tests {
     async fn test_server_context_shutdown_with_no_dispatcher() {
         // A context without webhooks should be able to shut down without panic
         let config = create_minimal_config();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         assert!(context.event_dispatcher().is_none());
@@ -908,7 +916,7 @@ pub mod tests {
         );
 
         let config: Configuration = toml::from_str(&toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         let event = Event {
@@ -973,7 +981,7 @@ pub mod tests {
         );
 
         let config: Configuration = toml::from_str(&toml).unwrap();
-        let registry = create_test_registry(&config);
+        let registry = create_test_registry(&config).await;
         let context = ServerContext::new(&config, registry).unwrap();
 
         // Shut down first, then try to dispatch
@@ -1044,9 +1052,10 @@ pub mod tests {
             lock_strategy: crate::registry::metadata_store::LockStrategy::Memory,
             link_cache_ttl: 0, // disable link cache so reads go to S3
             access_time_debounce_secs: 3600,
+            capabilities: None,
         };
 
-        let metadata_backend = S3MetadataBackend::new(&s3_config).unwrap();
+        let metadata_backend = S3MetadataBackend::new(&s3_config, None).unwrap();
         let metadata_store: Arc<dyn MetadataStore + Send + Sync> = Arc::new(metadata_backend);
 
         // Build a FS blob store (blobs aren't exercised in this test)
@@ -1145,8 +1154,8 @@ pub mod tests {
         );
     }
 
-    #[test]
-    fn test_server_context_new_invalid_cache_config() {
+    #[tokio::test]
+    async fn test_server_context_new_invalid_cache_config() {
         let toml = r#"
             [blob_store.fs]
             root_dir = "/tmp/test"
@@ -1170,7 +1179,11 @@ pub mod tests {
         let config: Configuration = toml::from_str(toml).unwrap();
 
         let blob_store = config.blob_store.to_backend().unwrap();
-        let metadata_store = config.resolve_metadata_config().to_backend(None).unwrap();
+        let metadata_store = config
+            .resolve_metadata_config()
+            .to_backend(None)
+            .await
+            .unwrap();
         let repositories = Arc::new(HashMap::new());
 
         let registry_config = RegistryConfig::new()

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -234,8 +234,8 @@ impl Configuration {
                 blob_store::BlobStorageConfig::FS(config) => {
                     metadata_store::MetadataStoreConfig::FS(metadata_store::fs::BackendConfig {
                         root_dir: config.root_dir.clone(),
-                        redis: None,
                         sync_to_disk: config.sync_to_disk,
+                        ..Default::default()
                     })
                 }
                 blob_store::BlobStorageConfig::S3(config) => {
@@ -247,9 +247,7 @@ impl Configuration {
                         access_key_id: config.access_key_id.clone(),
                         secret_key: config.secret_key.clone(),
                         key_prefix: config.key_prefix.clone(),
-                        redis: None,
-                        link_cache_ttl: 30,
-                        access_time_debounce_secs: 60,
+                        ..Default::default()
                     })
                 }
             },
@@ -509,7 +507,10 @@ mod tests {
             metadata_store::MetadataStoreConfig::FS(fs_config) => {
                 assert_eq!(fs_config.root_dir, "/data/blobs");
                 assert!(fs_config.sync_to_disk);
-                assert!(fs_config.redis.is_none());
+                assert_eq!(
+                    fs_config.lock_strategy,
+                    metadata_store::LockStrategy::Memory
+                );
             }
             metadata_store::MetadataStoreConfig::S3(_) => {
                 panic!("Expected FS metadata store config")
@@ -543,7 +544,10 @@ mod tests {
                 assert_eq!(s3_config.access_key_id, "key123");
                 assert_eq!(s3_config.secret_key, "secret456");
                 assert_eq!(s3_config.key_prefix, "prefix/");
-                assert!(s3_config.redis.is_none());
+                assert_eq!(
+                    s3_config.lock_strategy,
+                    metadata_store::LockStrategy::Memory
+                );
             }
             metadata_store::MetadataStoreConfig::FS(_) => {
                 panic!("Expected S3 metadata store config")
@@ -885,8 +889,13 @@ mod tests {
         match metadata_config {
             metadata_store::MetadataStoreConfig::S3(s3_config) => {
                 assert_eq!(s3_config.bucket, "metadata-bucket");
-                assert!(s3_config.redis.is_some());
-                assert_eq!(s3_config.redis.unwrap().url, "redis://localhost:6379");
+                match &s3_config.lock_strategy {
+                    metadata_store::LockStrategy::Redis(lock_config) => {
+                        assert_eq!(lock_config.url, "redis://localhost:6379");
+                        assert_eq!(lock_config.ttl, 30);
+                    }
+                    other => panic!("Expected Redis lock strategy, got {other:?}"),
+                }
             }
             metadata_store::MetadataStoreConfig::FS(_) => {
                 panic!("Expected S3 metadata store config")
@@ -914,8 +923,13 @@ mod tests {
         match metadata_config {
             metadata_store::MetadataStoreConfig::FS(fs_config) => {
                 assert_eq!(fs_config.root_dir, "/data/metadata");
-                assert!(fs_config.redis.is_some());
-                assert_eq!(fs_config.redis.unwrap().url, "redis://localhost:6379");
+                match &fs_config.lock_strategy {
+                    metadata_store::LockStrategy::Redis(lock_config) => {
+                        assert_eq!(lock_config.url, "redis://localhost:6379");
+                        assert_eq!(lock_config.ttl, 30);
+                    }
+                    other => panic!("Expected Redis lock strategy, got {other:?}"),
+                }
             }
             metadata_store::MetadataStoreConfig::S3(_) => {
                 panic!("Expected FS metadata store config")
@@ -1341,5 +1355,197 @@ mod tests {
             }
             _ => panic!("Expected InvalidFormat error"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_metadata_store_s3_lock_strategy_s3_defaults() {
+        let config = r#"
+        [server]
+        bind_address = "0.0.0.0"
+
+        [blob_store.s3]
+        bucket = "blob-bucket"
+        region = "us-east-1"
+        endpoint = "https://s3.amazonaws.com"
+        access_key_id = "blob-key"
+        secret_key = "blob-secret"
+
+        [metadata_store.s3]
+        bucket = "metadata-bucket"
+        region = "us-east-1"
+        endpoint = "https://s3.amazonaws.com"
+        access_key_id = "key"
+        secret_key = "secret"
+
+        [metadata_store.s3.lock_strategy.s3]
+        "#;
+
+        let config = Configuration::load_from_str(config).unwrap();
+        let metadata_config = config.resolve_metadata_config();
+
+        match metadata_config {
+            metadata_store::MetadataStoreConfig::S3(s3_config) => {
+                assert_eq!(s3_config.bucket, "metadata-bucket");
+                match &s3_config.lock_strategy {
+                    metadata_store::LockStrategy::S3(lock_config) => {
+                        assert_eq!(lock_config.ttl_secs, 30);
+                        assert_eq!(lock_config.max_retries, 100);
+                        assert_eq!(lock_config.retry_delay_ms, 50);
+                    }
+                    other => panic!("Expected S3 lock strategy, got {other:?}"),
+                }
+            }
+            metadata_store::MetadataStoreConfig::FS(_) => {
+                panic!("Expected S3 metadata store config")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_metadata_store_s3_lock_strategy_s3_custom_values() {
+        let config = r#"
+        [server]
+        bind_address = "0.0.0.0"
+
+        [blob_store.s3]
+        bucket = "blob-bucket"
+        region = "us-east-1"
+        endpoint = "https://s3.amazonaws.com"
+        access_key_id = "blob-key"
+        secret_key = "blob-secret"
+
+        [metadata_store.s3]
+        bucket = "metadata-bucket"
+        region = "us-east-1"
+        endpoint = "https://s3.amazonaws.com"
+        access_key_id = "key"
+        secret_key = "secret"
+
+        [metadata_store.s3.lock_strategy.s3]
+        ttl_secs = 60
+        max_retries = 50
+        retry_delay_ms = 100
+        "#;
+
+        let config = Configuration::load_from_str(config).unwrap();
+        let metadata_config = config.resolve_metadata_config();
+
+        match metadata_config {
+            metadata_store::MetadataStoreConfig::S3(s3_config) => match &s3_config.lock_strategy {
+                metadata_store::LockStrategy::S3(lock_config) => {
+                    assert_eq!(lock_config.ttl_secs, 60);
+                    assert_eq!(lock_config.max_retries, 50);
+                    assert_eq!(lock_config.retry_delay_ms, 100);
+                }
+                other => panic!("Expected S3 lock strategy, got {other:?}"),
+            },
+            metadata_store::MetadataStoreConfig::FS(_) => {
+                panic!("Expected S3 metadata store config")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_metadata_store_s3_lock_strategy_memory() {
+        let config = r#"
+        [server]
+        bind_address = "0.0.0.0"
+
+        [blob_store.s3]
+        bucket = "blob-bucket"
+        region = "us-east-1"
+        endpoint = "https://s3.amazonaws.com"
+        access_key_id = "blob-key"
+        secret_key = "blob-secret"
+
+        [metadata_store.s3]
+        bucket = "metadata-bucket"
+        region = "us-east-1"
+        endpoint = "https://s3.amazonaws.com"
+        access_key_id = "key"
+        secret_key = "secret"
+        lock_strategy = "memory"
+        "#;
+
+        let config = Configuration::load_from_str(config).unwrap();
+        let metadata_config = config.resolve_metadata_config();
+
+        match metadata_config {
+            metadata_store::MetadataStoreConfig::S3(s3_config) => {
+                assert!(
+                    matches!(
+                        s3_config.lock_strategy,
+                        metadata_store::LockStrategy::Memory
+                    ),
+                    "Expected Memory lock strategy, got {:?}",
+                    s3_config.lock_strategy
+                );
+            }
+            metadata_store::MetadataStoreConfig::FS(_) => {
+                panic!("Expected S3 metadata store config")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_metadata_store_s3_both_redis_and_lock_strategy_fails() {
+        let config = r#"
+        [server]
+        bind_address = "0.0.0.0"
+
+        [blob_store.s3]
+        bucket = "blob-bucket"
+        region = "us-east-1"
+        endpoint = "https://s3.amazonaws.com"
+        access_key_id = "blob-key"
+        secret_key = "blob-secret"
+
+        [metadata_store.s3]
+        bucket = "metadata-bucket"
+        region = "us-east-1"
+        endpoint = "https://s3.amazonaws.com"
+        access_key_id = "key"
+        secret_key = "secret"
+        lock_strategy = "memory"
+
+        [metadata_store.s3.redis]
+        url = "redis://localhost:6379"
+        ttl = 30
+        "#;
+
+        let result = Configuration::load_from_str(config);
+        assert!(
+            result.is_err(),
+            "Expected error when both redis and lock_strategy are set"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("lock_strategy") && err_msg.contains("redis"),
+            "Error should mention both 'lock_strategy' and 'redis', got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_metadata_store_fs_lock_strategy_s3_fails() {
+        let config = r#"
+        [server]
+        bind_address = "0.0.0.0"
+
+        [metadata_store.fs]
+        root_dir = "/data/metadata"
+
+        [metadata_store.fs.lock_strategy.s3]
+        "#;
+
+        let result = Configuration::load_from_str(config);
+        assert!(
+            result.is_err(),
+            "Expected error when S3 lock strategy is used with FS metadata store"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("S3 lock strategy") || err_msg.contains("filesystem"),
+            "Error should explain S3 lock strategy is unsupported for FS store, got: {err_msg}"
+        );
     }
 }

--- a/src/identity/route.rs
+++ b/src/identity/route.rs
@@ -26,6 +26,7 @@ pub enum Route<'a> {
     #[serde(rename = "ui-config")]
     UiConfig,
     Healthz,
+    Readyz,
     Metrics,
     #[serde(rename = "get-api-version")]
     ApiVersion,
@@ -182,6 +183,7 @@ impl Route<'_> {
             Route::UiConfig => "ui-config",
             Route::ApiVersion => "get-api-version",
             Route::Healthz => "healthz",
+            Route::Readyz => "readyz",
             Route::Metrics => "metrics",
             Route::ListCatalog { .. } => "list-catalog",
             Route::ListTags { .. } => "list-tags",
@@ -405,6 +407,7 @@ mod tests {
         let test_cases = vec![
             (Route::ApiVersion, "get-api-version"),
             (Route::Healthz, "healthz"),
+            (Route::Readyz, "readyz"),
             (Route::Metrics, "metrics"),
             (
                 Route::ListCatalog {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,18 +145,12 @@ async fn run_command(cli_args: GlobalArguments, config: Configuration) {
 }
 
 async fn run_scrub(options: scrub::Options, config: Configuration) -> Result<(), scrub::Error> {
-    let scrub = scrub::Command::new(&options, &config)?;
+    let scrub = scrub::Command::new(&options, &config).await?;
     scrub.run().await
 }
 
 async fn run_server(options: GlobalArguments, config: Configuration) -> Result<(), server::Error> {
-    config
-        .resolve_metadata_config()
-        .probe()
-        .await
-        .map_err(|e| server::Error::Initialization(e.to_string()))?;
-
-    let server = Arc::new(server::Command::new(&config)?);
+    let server = Arc::new(server::Command::new(&config).await?);
 
     let Ok(_watcher) = ConfigWatcher::new(&options.config, server.clone()) else {
         error!("Failed to start configuration watcher");

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,12 @@ async fn run_scrub(options: scrub::Options, config: Configuration) -> Result<(),
 }
 
 async fn run_server(options: GlobalArguments, config: Configuration) -> Result<(), server::Error> {
+    config
+        .resolve_metadata_config()
+        .probe()
+        .await
+        .map_err(|e| server::Error::Initialization(e.to_string()))?;
+
     let server = Arc::new(server::Command::new(&config)?);
 
     let Ok(_watcher) = ConfigWatcher::new(&options.config, server.clone()) else {

--- a/src/metrics_provider.rs
+++ b/src/metrics_provider.rs
@@ -21,6 +21,56 @@ pub static AUTH_ATTEMPTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("Failed to register auth_attempts metric")
 });
 
+pub static LOCK_ACQUISITION_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec_with_registry!(
+        "lock_acquisition_duration_ms",
+        "Lock acquisition duration in milliseconds",
+        &["backend"],
+        &METRICS_PROVIDER.registry
+    )
+    .expect("Failed to register lock_acquisition_duration_ms metric")
+});
+
+pub static LOCK_ACQUISITIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec_with_registry!(
+        "lock_acquisitions_total",
+        "Total lock acquisition attempts",
+        &["backend", "result"],
+        &METRICS_PROVIDER.registry
+    )
+    .expect("Failed to register lock_acquisitions_total metric")
+});
+
+pub static LOCK_RETRIES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec_with_registry!(
+        "lock_retries_total",
+        "Total lock acquisition retries",
+        &["backend"],
+        &METRICS_PROVIDER.registry
+    )
+    .expect("Failed to register lock_retries_total metric")
+});
+
+pub static LOCK_INVALIDATIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec_with_registry!(
+        "lock_invalidations_total",
+        "Total lock invalidations",
+        &["backend", "reason"],
+        &METRICS_PROVIDER.registry
+    )
+    .expect("Failed to register lock_invalidations_total metric")
+});
+
+pub static LOCK_RECOVERIES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec_with_registry!(
+        "lock_recoveries_total",
+        "Total stale lock recovery attempts",
+        &["backend", "result"],
+        &METRICS_PROVIDER.registry
+    )
+    .expect("Failed to register lock_recoveries_total metric")
+});
+
 pub static METRICS_PROVIDER: LazyLock<MetricsProvider> = LazyLock::new(|| {
     MetricsProvider::new()
         .unwrap_or_else(|error| panic!("Unable to create metrics provider: {error}"))

--- a/src/registry/blob.rs
+++ b/src/registry/blob.rs
@@ -14,7 +14,7 @@ use crate::{
     registry::{
         Error, Registry, Repository,
         blob_store::{BlobStore, BoxedReader},
-        metadata_store::{MetadataStoreExt, link_kind::LinkKind},
+        metadata_store::{self, BlobIndexOperation, MetadataStoreExt, link_kind::LinkKind},
         task_queue,
     },
 };
@@ -35,6 +35,24 @@ pub struct HeadBlobResponse {
 }
 
 impl Registry {
+    async fn check_blob_namespace_access(
+        &self,
+        namespace: &Namespace,
+        digest: &Digest,
+    ) -> Result<(), Error> {
+        match self.metadata_store.read_blob_index(digest).await {
+            Ok(blob_index) => {
+                if blob_index.namespace.contains_key(namespace.as_ref()) {
+                    Ok(())
+                } else {
+                    Err(Error::BlobUnknown)
+                }
+            }
+            Err(metadata_store::Error::ReferenceNotFound) => Ok(()),
+            Err(_) => Err(Error::BlobUnknown),
+        }
+    }
+
     #[instrument(skip(repository))]
     pub async fn head_blob(
         &self,
@@ -43,6 +61,10 @@ impl Registry {
         namespace: &Namespace,
         digest: &Digest,
     ) -> Result<HeadBlobResponse, Error> {
+        if !repository.is_pull_through() {
+            self.check_blob_namespace_access(namespace, digest).await?;
+        }
+
         let blob = self.blob_store.get_blob_size(digest).await;
 
         match blob {
@@ -98,6 +120,10 @@ impl Registry {
         digest: &Digest,
         range: Option<(u64, Option<u64>)>,
     ) -> Result<GetBlobResponse<BoxedReader>, Error> {
+        if !repository.is_pull_through() {
+            self.check_blob_namespace_access(namespace, digest).await?;
+        }
+
         let local_blob = self.get_local_blob(digest, range).await;
 
         if let Ok(response) = local_blob {
@@ -184,6 +210,34 @@ impl Registry {
             warn!("Failed to delete blob links: {error}");
         }
 
+        // Remove all remaining blob index entries for this namespace
+        if let Ok(blob_index) = self.metadata_store.read_blob_index(digest).await
+            && let Some(links) = blob_index.namespace.get(namespace.as_ref())
+        {
+            for link in links {
+                if let Err(error) = self
+                    .metadata_store
+                    .update_blob_index(
+                        namespace.as_ref(),
+                        digest,
+                        BlobIndexOperation::Remove(link.clone()),
+                    )
+                    .await
+                {
+                    warn!("Failed to remove blob index entry: {error}");
+                }
+            }
+        }
+
+        let should_delete = match self.metadata_store.read_blob_index(digest).await {
+            Ok(blob_index) => blob_index.namespace.is_empty(),
+            Err(_) => true,
+        };
+
+        if should_delete && let Err(error) = self.blob_store.delete_blob(digest).await {
+            warn!("Failed to delete blob data: {error}");
+        }
+
         Ok(())
     }
 
@@ -235,6 +289,10 @@ impl Registry {
         range: Option<(u64, Option<u64>)>,
     ) -> Result<Response<ResponseBody>, Error> {
         let repository = self.get_repository_for_namespace(namespace)?;
+
+        if !repository.is_pull_through() {
+            self.check_blob_namespace_access(namespace, digest).await?;
+        }
 
         if range.is_none()
             && self.enable_redirect
@@ -486,10 +544,8 @@ mod tests {
 
             let layer_link = LinkKind::Layer(digest.clone());
             let config_link = LinkKind::Config(digest.clone());
-            let latest_link = LinkKind::Tag("latest".to_string());
 
             let mut tx = registry.metadata_store.begin_transaction(namespace);
-            tx.create_link(&layer_link, &digest);
             tx.create_link(&config_link, &digest);
             tx.commit().await.unwrap();
 
@@ -507,15 +563,14 @@ mod tests {
                     .await
                     .is_ok()
             );
+
+            let accepted_content_types = Vec::new();
             assert!(
                 registry
-                    .metadata_store
-                    .read_link(namespace, &latest_link, false)
+                    .handle_head_blob(namespace, &digest, &accepted_content_types)
                     .await
                     .is_ok()
             );
-
-            assert!(registry.blob_store.read_blob(&digest).await.is_ok());
 
             let response = registry
                 .handle_delete_blob(namespace, &digest)
@@ -523,10 +578,6 @@ mod tests {
                 .unwrap();
 
             assert_eq!(response.status(), StatusCode::ACCEPTED);
-
-            let mut tx = registry.metadata_store.begin_transaction(namespace);
-            tx.delete_link(&latest_link);
-            tx.commit().await.unwrap();
 
             assert!(
                 registry
@@ -542,18 +593,14 @@ mod tests {
                     .await
                     .is_err()
             );
+
             assert!(
                 registry
-                    .metadata_store
-                    .read_link(namespace, &latest_link, false)
+                    .handle_head_blob(namespace, &digest, &accepted_content_types)
                     .await
-                    .is_err()
+                    .is_err(),
+                "Blob should be inaccessible after deletion"
             );
-
-            let blob_index = registry.metadata_store.read_blob_index(&digest).await;
-            assert!(blob_index.is_err());
-
-            assert!(registry.blob_store.read_blob(&digest).await.is_err());
         }
     }
 

--- a/src/registry/blob.rs
+++ b/src/registry/blob.rs
@@ -49,7 +49,10 @@ impl Registry {
                 }
             }
             Err(metadata_store::Error::ReferenceNotFound) => Ok(()),
-            Err(_) => Err(Error::BlobUnknown),
+            Err(e) => {
+                warn!("Failed to read blob index for {digest}: {e}");
+                Err(Error::Internal(format!("storage error: {e}")))
+            }
         }
     }
 
@@ -290,10 +293,6 @@ impl Registry {
     ) -> Result<Response<ResponseBody>, Error> {
         let repository = self.get_repository_for_namespace(namespace)?;
 
-        if !repository.is_pull_through() {
-            self.check_blob_namespace_access(namespace, digest).await?;
-        }
-
         if range.is_none()
             && self.enable_redirect
             && let Ok(Some(presigned_url)) = self.blob_store.get_blob_url(digest).await
@@ -312,7 +311,6 @@ impl Registry {
         {
             GetBlobResponse::RangedReader(reader, (start, end), total_length) => {
                 let length = end - start + 1;
-                let stream = reader.take(length);
                 let range = format!("bytes {start}-{end}/{total_length}");
 
                 Response::builder()
@@ -321,7 +319,7 @@ impl Registry {
                     .header(ACCEPT_RANGES, "bytes")
                     .header(CONTENT_LENGTH, length.to_string())
                     .header(CONTENT_RANGE, range)
-                    .body(ResponseBody::streaming(stream))?
+                    .body(ResponseBody::streaming(reader))?
             }
             GetBlobResponse::Reader(stream, total_length) => Response::builder()
                 .status(StatusCode::OK)

--- a/src/registry/blob.rs
+++ b/src/registry/blob.rs
@@ -293,6 +293,10 @@ impl Registry {
     ) -> Result<Response<ResponseBody>, Error> {
         let repository = self.get_repository_for_namespace(namespace)?;
 
+        if !repository.is_pull_through() {
+            self.check_blob_namespace_access(namespace, digest).await?;
+        }
+
         if range.is_none()
             && self.enable_redirect
             && let Ok(Some(presigned_url)) = self.blob_store.get_blob_url(digest).await

--- a/src/registry/blob_store/error.rs
+++ b/src/registry/blob_store/error.rs
@@ -6,7 +6,7 @@ use aws_sdk_s3::{
     operation::{get_object::GetObjectError, head_object::HeadObjectError},
     primitives::ByteStreamError,
 };
-use sha2::digest::crypto_common::hazmat::DeserializeStateError;
+use sha2::digest::common::hazmat::DeserializeStateError;
 use tracing::error;
 
 use crate::{oci, registry::data_store};
@@ -139,7 +139,7 @@ mod tests {
         },
         primitives::ByteStreamError,
     };
-    use sha2::digest::crypto_common::hazmat::DeserializeStateError;
+    use sha2::digest::common::hazmat::DeserializeStateError;
 
     use super::*;
 

--- a/src/registry/blob_store/sha256_ext.rs
+++ b/src/registry/blob_store/sha256_ext.rs
@@ -1,5 +1,4 @@
 use sha2::{Digest, Sha256, digest::crypto_common::hazmat::SerializableState};
-
 use crate::{oci, registry::blob_store::Error};
 
 pub trait Sha256Ext {

--- a/src/registry/blob_store/sha256_ext.rs
+++ b/src/registry/blob_store/sha256_ext.rs
@@ -1,4 +1,5 @@
 use sha2::{Digest, Sha256, digest::crypto_common::hazmat::SerializableState};
+
 use crate::{oci, registry::blob_store::Error};
 
 pub trait Sha256Ext {

--- a/src/registry/blob_store/sha256_ext.rs
+++ b/src/registry/blob_store/sha256_ext.rs
@@ -1,4 +1,4 @@
-use sha2::{Digest, Sha256, digest::crypto_common::hazmat::SerializableState};
+use sha2::{Digest, Sha256, digest::common::hazmat::SerializableState};
 
 use crate::{oci, registry::blob_store::Error};
 

--- a/src/registry/data_store/error.rs
+++ b/src/registry/data_store/error.rs
@@ -6,6 +6,7 @@ pub enum Error {
     Io(String),
     Serialization(String),
     NotFound(String),
+    PreconditionFailed,
 }
 
 impl fmt::Display for Error {
@@ -15,6 +16,7 @@ impl fmt::Display for Error {
             Error::Io(e) => write!(f, "IO error: {e}"),
             Error::Serialization(e) => write!(f, "Serialization error: {e}"),
             Error::NotFound(e) => write!(f, "Not found: {e}"),
+            Error::PreconditionFailed => write!(f, "Precondition failed"),
         }
     }
 }
@@ -60,6 +62,10 @@ mod tests {
         assert_eq!(
             format!("{}", Error::NotFound("file.txt".to_string())),
             "Not found: file.txt"
+        );
+        assert_eq!(
+            format!("{}", Error::PreconditionFailed),
+            "Precondition failed"
         );
     }
 

--- a/src/registry/data_store/s3.rs
+++ b/src/registry/data_store/s3.rs
@@ -418,7 +418,7 @@ impl Backend {
         &self,
         path: &str,
         data: impl Into<Bytes>,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<String>, Error> {
         let key = self.full_key(path);
 
         let result = self
@@ -432,7 +432,10 @@ impl Backend {
             .await;
 
         match result {
-            Ok(_) => Ok(()),
+            Ok(output) => {
+                let etag = output.e_tag().map(|t| t.trim_matches('"').to_string());
+                Ok(etag)
+            }
             Err(e) => Err(classify_conditional_put_error(&e.into_service_error())),
         }
     }
@@ -442,7 +445,7 @@ impl Backend {
         path: &str,
         etag: &str,
         data: impl Into<Bytes>,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<String>, Error> {
         let key = self.full_key(path);
 
         let result = self
@@ -456,7 +459,10 @@ impl Backend {
             .await;
 
         match result {
-            Ok(_) => Ok(()),
+            Ok(output) => {
+                let etag = output.e_tag().map(|t| t.trim_matches('"').to_string());
+                Ok(etag)
+            }
             Err(e) => Err(classify_conditional_put_error(&e.into_service_error())),
         }
     }

--- a/src/registry/data_store/s3.rs
+++ b/src/registry/data_store/s3.rs
@@ -578,6 +578,32 @@ impl Backend {
         mapped
     }
 
+    pub async fn delete_if_match(&self, path: &str, etag: &str) -> Result<(), Error> {
+        self.check_circuit_breaker()
+            .map_err(|e| Error::Io(e.to_string()))?;
+        let key = self.full_key(path);
+
+        let result = self
+            .s3_client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .if_match(etag)
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                let service_err = e.into_service_error();
+                if is_conditional_write_conflict(&service_err) {
+                    Error::PreconditionFailed
+                } else {
+                    Error::Io(service_err.to_string())
+                }
+            });
+        self.record_data_result(&result);
+        result
+    }
+
     pub async fn put_object(&self, path: &str, data: impl Into<Bytes>) -> Result<(), IoError> {
         self.check_circuit_breaker()?;
         let key = self.full_key(path);

--- a/src/registry/data_store/s3.rs
+++ b/src/registry/data_store/s3.rs
@@ -6,6 +6,7 @@ use std::{
 use aws_sdk_s3::{
     Client as S3Client, Config as S3Config,
     config::{BehaviorVersion, Credentials, Region, retry::RetryConfig, timeout::TimeoutConfig},
+    error::ProvideErrorMetadata,
     operation::get_object::GetObjectOutput,
     primitives::ByteStream,
     types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier},
@@ -55,11 +56,29 @@ impl Default for BackendConfig {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Backend {
     s3_client: S3Client,
     bucket: String,
     key_prefix: String,
+}
+
+const S3_ERROR_PRECONDITION_FAILED: &str = "PreconditionFailed";
+const S3_ERROR_CONDITIONAL_REQUEST_CONFLICT: &str = "ConditionalRequestConflict";
+
+fn is_conditional_write_conflict(error: &(impl ProvideErrorMetadata + std::fmt::Display)) -> bool {
+    let code = error.code().unwrap_or_default();
+    code == S3_ERROR_PRECONDITION_FAILED || code == S3_ERROR_CONDITIONAL_REQUEST_CONFLICT
+}
+
+fn classify_conditional_put_error(
+    error: &(impl ProvideErrorMetadata + std::fmt::Display),
+) -> Error {
+    if is_conditional_write_conflict(error) {
+        Error::PreconditionFailed
+    } else {
+        Error::Io(error.to_string())
+    }
 }
 
 impl Backend {
@@ -119,6 +138,19 @@ impl Backend {
     }
 
     pub async fn read(&self, path: &str) -> Result<Vec<u8>, IoError> {
+        let (body, _) = self.read_with_etag(path).await?;
+        Ok(body)
+    }
+
+    pub async fn read_with_etag(&self, path: &str) -> Result<(Vec<u8>, Option<String>), IoError> {
+        let (body, etag, _) = self.read_with_metadata(path).await?;
+        Ok((body, etag))
+    }
+
+    pub async fn read_with_metadata(
+        &self,
+        path: &str,
+    ) -> Result<(Vec<u8>, Option<String>, Option<DateTime<Utc>>), IoError> {
         let key = self.full_key(path);
 
         let result = self
@@ -137,13 +169,22 @@ impl Backend {
                 }
             })?;
 
+        let etag = result
+            .e_tag
+            .as_deref()
+            .map(|t| t.trim_matches('"').to_string());
+
+        let last_modified = result
+            .last_modified
+            .and_then(|lm| DateTime::from_timestamp(lm.secs(), lm.subsec_nanos()));
+
         let body = result
             .body
             .collect()
             .await
             .map_err(|e| IoError::other(e.to_string()))?;
 
-        Ok(body.into_bytes().to_vec())
+        Ok((body.into_bytes().to_vec(), etag, last_modified))
     }
 
     pub async fn delete(&self, path: &str) -> Result<(), IoError> {
@@ -371,6 +412,53 @@ impl Backend {
                 IoError::other(service_error.to_string())
             }
         })
+    }
+
+    pub async fn put_object_if_not_exists(
+        &self,
+        path: &str,
+        data: impl Into<Bytes>,
+    ) -> Result<(), Error> {
+        let key = self.full_key(path);
+
+        let result = self
+            .s3_client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .if_none_match("*")
+            .body(ByteStream::from(data.into()))
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) => Err(classify_conditional_put_error(&e.into_service_error())),
+        }
+    }
+
+    pub async fn put_object_if_match(
+        &self,
+        path: &str,
+        etag: &str,
+        data: impl Into<Bytes>,
+    ) -> Result<(), Error> {
+        let key = self.full_key(path);
+
+        let result = self
+            .s3_client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .if_match(etag)
+            .body(ByteStream::from(data.into()))
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) => Err(classify_conditional_put_error(&e.into_service_error())),
+        }
     }
 
     pub async fn put_object(&self, path: &str, data: impl Into<Bytes>) -> Result<(), IoError> {

--- a/src/registry/data_store/s3.rs
+++ b/src/registry/data_store/s3.rs
@@ -1,5 +1,9 @@
 use std::{
     io::{Error as IoError, ErrorKind},
+    sync::{
+        Arc,
+        atomic::{AtomicU32, AtomicU64, Ordering},
+    },
     time::Duration,
 };
 
@@ -15,8 +19,67 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use tracing::warn;
 
 use crate::registry::data_store::Error;
+
+const CIRCUIT_BREAKER_THRESHOLD: u32 = 5;
+const CIRCUIT_BREAKER_COOLDOWN_SECS: u64 = 10;
+
+#[derive(Clone, Debug)]
+struct CircuitBreaker {
+    consecutive_failures: Arc<AtomicU32>,
+    opened_at_epoch_secs: Arc<AtomicU64>,
+}
+
+impl CircuitBreaker {
+    fn new() -> Self {
+        Self {
+            consecutive_failures: Arc::new(AtomicU32::new(0)),
+            opened_at_epoch_secs: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn check(&self) -> Result<(), IoError> {
+        let failures = self.consecutive_failures.load(Ordering::Acquire);
+        if failures < CIRCUIT_BREAKER_THRESHOLD {
+            return Ok(());
+        }
+        let opened_at = self.opened_at_epoch_secs.load(Ordering::Acquire);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if now.saturating_sub(opened_at) >= CIRCUIT_BREAKER_COOLDOWN_SECS {
+            // Half-open: allow one probe request through
+            return Ok(());
+        }
+        Err(IoError::other(format!(
+            "S3 circuit breaker open: {failures} consecutive failures, \
+             cooling down for {CIRCUIT_BREAKER_COOLDOWN_SECS}s"
+        )))
+    }
+
+    fn record_success(&self) {
+        self.consecutive_failures.store(0, Ordering::Release);
+    }
+
+    fn record_failure(&self) {
+        let prev = self.consecutive_failures.fetch_add(1, Ordering::AcqRel);
+        if prev + 1 == CIRCUIT_BREAKER_THRESHOLD {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            self.opened_at_epoch_secs.store(now, Ordering::Release);
+            warn!(
+                threshold = CIRCUIT_BREAKER_THRESHOLD,
+                cooldown_secs = CIRCUIT_BREAKER_COOLDOWN_SECS,
+                "S3 circuit breaker opened after {CIRCUIT_BREAKER_THRESHOLD} consecutive failures"
+            );
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(default)]
@@ -61,6 +124,7 @@ pub struct Backend {
     s3_client: S3Client,
     bucket: String,
     key_prefix: String,
+    circuit_breaker: CircuitBreaker,
 }
 
 const S3_ERROR_PRECONDITION_FAILED: &str = "PreconditionFailed";
@@ -126,7 +190,31 @@ impl Backend {
             s3_client,
             bucket: config.bucket.clone(),
             key_prefix: config.key_prefix.clone(),
+            circuit_breaker: CircuitBreaker::new(),
         })
+    }
+
+    fn check_circuit_breaker(&self) -> Result<(), IoError> {
+        self.circuit_breaker.check()
+    }
+
+    fn record_io_result<T>(&self, result: &Result<T, IoError>) {
+        match result {
+            Ok(_) => self.circuit_breaker.record_success(),
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                self.circuit_breaker.record_success();
+            }
+            Err(_) => self.circuit_breaker.record_failure(),
+        }
+    }
+
+    fn record_data_result<T>(&self, result: &Result<T, Error>) {
+        match result {
+            Ok(_) | Err(Error::PreconditionFailed | Error::NotFound(_)) => {
+                self.circuit_breaker.record_success();
+            }
+            Err(_) => self.circuit_breaker.record_failure(),
+        }
     }
 
     fn full_key(&self, path: &str) -> String {
@@ -151,6 +239,7 @@ impl Backend {
         &self,
         path: &str,
     ) -> Result<(Vec<u8>, Option<String>, Option<DateTime<Utc>>), IoError> {
+        self.check_circuit_breaker()?;
         let key = self.full_key(path);
 
         let result = self
@@ -167,7 +256,9 @@ impl Backend {
                 } else {
                     IoError::other(service_error.to_string())
                 }
-            })?;
+            });
+        self.record_io_result(&result);
+        let result = result?;
 
         let etag = result
             .e_tag
@@ -188,17 +279,20 @@ impl Backend {
     }
 
     pub async fn delete(&self, path: &str) -> Result<(), IoError> {
+        self.check_circuit_breaker()?;
         let key = self.full_key(path);
 
-        self.s3_client
+        let result = self
+            .s3_client
             .delete_object()
             .bucket(&self.bucket)
             .key(&key)
             .send()
             .await
-            .map_err(|e| IoError::other(e.to_string()))?;
-
-        Ok(())
+            .map_err(|e| IoError::other(e.to_string()))
+            .map(|_| ());
+        self.record_io_result(&result);
+        result
     }
 
     pub async fn delete_prefix(&self, prefix: &str) -> Result<(), IoError> {
@@ -263,6 +357,7 @@ impl Backend {
     }
 
     pub async fn object_size(&self, path: &str) -> Result<u64, IoError> {
+        self.check_circuit_breaker()?;
         let key = self.full_key(path);
 
         let result = self
@@ -279,7 +374,9 @@ impl Backend {
                 } else {
                     IoError::other(service_error.to_string())
                 }
-            })?;
+            });
+        self.record_io_result(&result);
+        let result = result?;
 
         Ok(result
             .content_length
@@ -296,6 +393,7 @@ impl Backend {
         continuation_token: Option<String>,
         start_after: Option<String>,
     ) -> Result<(Vec<String>, Vec<String>, Option<String>), IoError> {
+        self.check_circuit_breaker()?;
         let mut full_prefix = self.full_key(path);
         // Ensure prefix ends with / if not empty to list items inside the directory
         if !full_prefix.is_empty() && !full_prefix.ends_with('/') {
@@ -304,7 +402,7 @@ impl Backend {
 
         let full_start_after = start_after.map(|s| format!("{full_prefix}{s}{delimiter}"));
 
-        let res = self
+        let result = self
             .s3_client
             .list_objects_v2()
             .bucket(&self.bucket)
@@ -315,7 +413,9 @@ impl Backend {
             .set_start_after(full_start_after)
             .send()
             .await
-            .map_err(|e| IoError::other(e.to_string()))?;
+            .map_err(|e| IoError::other(e.to_string()));
+        self.record_io_result(&result);
+        let res = result?;
 
         let mut prefixes = Vec::new();
         for prefix in res.common_prefixes.unwrap_or_default() {
@@ -397,6 +497,7 @@ impl Backend {
         path: &str,
         offset: Option<u64>,
     ) -> Result<GetObjectOutput, IoError> {
+        self.check_circuit_breaker()?;
         let key = self.full_key(path);
         let mut req = self.s3_client.get_object().bucket(&self.bucket).key(&key);
 
@@ -404,14 +505,16 @@ impl Backend {
             req = req.range(format!("bytes={offset}-"));
         }
 
-        req.send().await.map_err(|e| {
+        let result = req.send().await.map_err(|e| {
             let service_error = e.into_service_error();
             if service_error.is_no_such_key() {
                 IoError::new(ErrorKind::NotFound, "object not found")
             } else {
                 IoError::other(service_error.to_string())
             }
-        })
+        });
+        self.record_io_result(&result);
+        result
     }
 
     pub async fn put_object_if_not_exists(
@@ -419,6 +522,8 @@ impl Backend {
         path: &str,
         data: impl Into<Bytes>,
     ) -> Result<Option<String>, Error> {
+        self.check_circuit_breaker()
+            .map_err(|e| Error::Io(e.to_string()))?;
         let key = self.full_key(path);
 
         let result = self
@@ -431,13 +536,15 @@ impl Backend {
             .send()
             .await;
 
-        match result {
+        let mapped = match result {
             Ok(output) => {
                 let etag = output.e_tag().map(|t| t.trim_matches('"').to_string());
                 Ok(etag)
             }
             Err(e) => Err(classify_conditional_put_error(&e.into_service_error())),
-        }
+        };
+        self.record_data_result(&mapped);
+        mapped
     }
 
     pub async fn put_object_if_match(
@@ -446,6 +553,8 @@ impl Backend {
         etag: &str,
         data: impl Into<Bytes>,
     ) -> Result<Option<String>, Error> {
+        self.check_circuit_breaker()
+            .map_err(|e| Error::Io(e.to_string()))?;
         let key = self.full_key(path);
 
         let result = self
@@ -458,28 +567,33 @@ impl Backend {
             .send()
             .await;
 
-        match result {
+        let mapped = match result {
             Ok(output) => {
                 let etag = output.e_tag().map(|t| t.trim_matches('"').to_string());
                 Ok(etag)
             }
             Err(e) => Err(classify_conditional_put_error(&e.into_service_error())),
-        }
+        };
+        self.record_data_result(&mapped);
+        mapped
     }
 
     pub async fn put_object(&self, path: &str, data: impl Into<Bytes>) -> Result<(), IoError> {
+        self.check_circuit_breaker()?;
         let key = self.full_key(path);
 
-        self.s3_client
+        let result = self
+            .s3_client
             .put_object()
             .bucket(&self.bucket)
             .key(&key)
             .body(ByteStream::from(data.into()))
             .send()
             .await
-            .map_err(|e| IoError::other(e.to_string()))?;
-
-        Ok(())
+            .map_err(|e| IoError::other(e.to_string()))
+            .map(|_| ());
+        self.record_io_result(&result);
+        result
     }
 
     pub async fn copy_object(&self, source: &str, destination: &str) -> Result<(), IoError> {

--- a/src/registry/metadata_store/config.rs
+++ b/src/registry/metadata_store/config.rs
@@ -6,7 +6,7 @@ use crate::{
     cache::Cache,
     registry::{
         data_store, metadata_store,
-        metadata_store::{Error, LockStrategy, MetadataStore},
+        metadata_store::{ConditionalCapabilities, Error, LockStrategy, MetadataStore},
     },
 };
 
@@ -20,22 +20,32 @@ pub enum MetadataStoreConfig {
 }
 
 impl MetadataStoreConfig {
-    pub async fn probe(&self) -> Result<(), Error> {
+    pub async fn probe(&self) -> Result<Option<ConditionalCapabilities>, Error> {
         match self {
             MetadataStoreConfig::S3(config) => match &config.lock_strategy {
                 LockStrategy::S3(lock_config) => {
                     let store =
                         data_store::s3::Backend::new(&config.to_lock_store_config(lock_config))
                             .map_err(|e| Error::StorageBackend(e.to_string()))?;
-                    metadata_store::s3::Backend::probe_conditional_write_support(&store).await
+                    let caps =
+                        metadata_store::s3::Backend::probe_conditional_capabilities(&store).await?;
+                    if !caps.supports_cas() {
+                        return Err(Error::Lock(format!(
+                            "S3 lock strategy requires If-None-Match and If-Match support, \
+                             but probe found: If-None-Match={}, If-Match={}. \
+                             Use lock_strategy = redis or lock_strategy = memory instead.",
+                            caps.put_if_none_match, caps.put_if_match
+                        )));
+                    }
+                    Ok(Some(caps))
                 }
-                _ => Ok(()),
+                _ => Ok(None),
             },
-            MetadataStoreConfig::FS(_) => Ok(()),
+            MetadataStoreConfig::FS(_) => Ok(None),
         }
     }
 
-    pub fn to_backend(
+    pub async fn to_backend(
         &self,
         cache: Option<Arc<dyn Cache>>,
     ) -> Result<Arc<dyn MetadataStore + Send + Sync>, Error> {
@@ -44,7 +54,23 @@ impl MetadataStoreConfig {
                 Ok(Arc::new(metadata_store::fs::Backend::new(config)?))
             }
             MetadataStoreConfig::S3(config) => {
-                let backend = metadata_store::s3::Backend::new(config)?;
+                let conditional = match &config.capabilities {
+                    Some(caps) => {
+                        if matches!(config.lock_strategy, LockStrategy::S3(_))
+                            && !caps.supports_cas()
+                        {
+                            return Err(Error::Lock(format!(
+                                "S3 lock strategy requires If-None-Match and If-Match support, \
+                                 but config declares: put_if_none_match={}, put_if_match={}. \
+                                 Use lock_strategy = redis or lock_strategy = memory instead.",
+                                caps.put_if_none_match, caps.put_if_match
+                            )));
+                        }
+                        Some(caps.clone())
+                    }
+                    None => self.probe().await?,
+                };
+                let backend = metadata_store::s3::Backend::new(config, conditional)?;
                 let backend = match cache {
                     Some(c) => backend.with_cache(c),
                     None => backend,
@@ -71,6 +97,7 @@ mod tests {
             lock_strategy: LockStrategy::S3(S3LockConfig::default()),
             link_cache_ttl: 30,
             access_time_debounce_secs: 0,
+            capabilities: None,
         })
     }
 
@@ -82,6 +109,14 @@ mod tests {
             result.is_ok(),
             "Probe should pass for S3 lock strategy on MinIO: {result:?}"
         );
+        let caps = result.unwrap();
+        assert!(
+            caps.is_some(),
+            "S3 lock strategy should return capabilities"
+        );
+        let caps = caps.unwrap();
+        assert!(caps.put_if_none_match, "MinIO should support If-None-Match");
+        assert!(caps.put_if_match, "MinIO should support If-Match");
     }
 
     #[tokio::test]
@@ -96,11 +131,16 @@ mod tests {
             lock_strategy: LockStrategy::Memory,
             link_cache_ttl: 30,
             access_time_debounce_secs: 0,
+            capabilities: None,
         });
         let result = config.probe().await;
         assert!(
             result.is_ok(),
             "Probe should be no-op for Memory lock strategy"
+        );
+        assert!(
+            result.unwrap().is_none(),
+            "Memory lock strategy should return no capabilities"
         );
     }
 
@@ -113,5 +153,9 @@ mod tests {
         });
         let result = config.probe().await;
         assert!(result.is_ok(), "Probe should be no-op for FS config");
+        assert!(
+            result.unwrap().is_none(),
+            "FS config should return no capabilities"
+        );
     }
 }

--- a/src/registry/metadata_store/config.rs
+++ b/src/registry/metadata_store/config.rs
@@ -5,8 +5,8 @@ use serde::Deserialize;
 use crate::{
     cache::Cache,
     registry::{
-        metadata_store,
-        metadata_store::{Error, MetadataStore},
+        data_store, metadata_store,
+        metadata_store::{Error, LockStrategy, MetadataStore},
     },
 };
 
@@ -20,6 +20,27 @@ pub enum MetadataStoreConfig {
 }
 
 impl MetadataStoreConfig {
+    pub async fn probe(&self) -> Result<(), Error> {
+        match self {
+            MetadataStoreConfig::S3(config)
+                if matches!(config.lock_strategy, LockStrategy::S3(_)) =>
+            {
+                let store = data_store::s3::Backend::new(&data_store::s3::BackendConfig {
+                    access_key_id: config.access_key_id.clone(),
+                    secret_key: config.secret_key.clone(),
+                    endpoint: config.endpoint.clone(),
+                    bucket: config.bucket.clone(),
+                    region: config.region.clone(),
+                    key_prefix: config.key_prefix.clone(),
+                    ..Default::default()
+                })
+                .map_err(|e| Error::StorageBackend(e.to_string()))?;
+                metadata_store::s3::Backend::probe_conditional_write_support(&store).await
+            }
+            _ => Ok(()),
+        }
+    }
+
     pub fn to_backend(
         &self,
         cache: Option<Arc<dyn Cache>>,
@@ -37,5 +58,66 @@ impl MetadataStoreConfig {
                 Ok(Arc::new(backend))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::metadata_store::lock::s3::S3LockConfig;
+
+    fn s3_config_with_s3_lock() -> MetadataStoreConfig {
+        MetadataStoreConfig::S3(metadata_store::s3::BackendConfig {
+            access_key_id: "root".to_string(),
+            secret_key: "roottoor".to_string(),
+            endpoint: "http://127.0.0.1:9000".to_string(),
+            bucket: "registry".to_string(),
+            region: "us-east-1".to_string(),
+            key_prefix: format!("probe-test-{}", uuid::Uuid::new_v4()),
+            lock_strategy: LockStrategy::S3(S3LockConfig::default()),
+            link_cache_ttl: 30,
+            access_time_debounce_secs: 0,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_probe_s3_lock_strategy() {
+        let config = s3_config_with_s3_lock();
+        let result = config.probe().await;
+        assert!(
+            result.is_ok(),
+            "Probe should pass for S3 lock strategy on MinIO: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_probe_memory_lock_strategy_is_noop() {
+        let config = MetadataStoreConfig::S3(metadata_store::s3::BackendConfig {
+            access_key_id: "root".to_string(),
+            secret_key: "roottoor".to_string(),
+            endpoint: "http://127.0.0.1:9000".to_string(),
+            bucket: "registry".to_string(),
+            region: "us-east-1".to_string(),
+            key_prefix: "probe-noop".to_string(),
+            lock_strategy: LockStrategy::Memory,
+            link_cache_ttl: 30,
+            access_time_debounce_secs: 0,
+        });
+        let result = config.probe().await;
+        assert!(
+            result.is_ok(),
+            "Probe should be no-op for Memory lock strategy"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_probe_fs_config_is_noop() {
+        let config = MetadataStoreConfig::FS(metadata_store::fs::BackendConfig {
+            root_dir: "/tmp/probe-test".to_string(),
+            lock_strategy: LockStrategy::Memory,
+            sync_to_disk: false,
+        });
+        let result = config.probe().await;
+        assert!(result.is_ok(), "Probe should be no-op for FS config");
     }
 }

--- a/src/registry/metadata_store/config.rs
+++ b/src/registry/metadata_store/config.rs
@@ -22,22 +22,16 @@ pub enum MetadataStoreConfig {
 impl MetadataStoreConfig {
     pub async fn probe(&self) -> Result<(), Error> {
         match self {
-            MetadataStoreConfig::S3(config)
-                if matches!(config.lock_strategy, LockStrategy::S3(_)) =>
-            {
-                let store = data_store::s3::Backend::new(&data_store::s3::BackendConfig {
-                    access_key_id: config.access_key_id.clone(),
-                    secret_key: config.secret_key.clone(),
-                    endpoint: config.endpoint.clone(),
-                    bucket: config.bucket.clone(),
-                    region: config.region.clone(),
-                    key_prefix: config.key_prefix.clone(),
-                    ..Default::default()
-                })
-                .map_err(|e| Error::StorageBackend(e.to_string()))?;
-                metadata_store::s3::Backend::probe_conditional_write_support(&store).await
-            }
-            _ => Ok(()),
+            MetadataStoreConfig::S3(config) => match &config.lock_strategy {
+                LockStrategy::S3(lock_config) => {
+                    let store =
+                        data_store::s3::Backend::new(&config.to_lock_store_config(lock_config))
+                            .map_err(|e| Error::StorageBackend(e.to_string()))?;
+                    metadata_store::s3::Backend::probe_conditional_write_support(&store).await
+                }
+                _ => Ok(()),
+            },
+            MetadataStoreConfig::FS(_) => Ok(()),
         }
     }
 

--- a/src/registry/metadata_store/error.rs
+++ b/src/registry/metadata_store/error.rs
@@ -29,6 +29,7 @@ impl From<data_store::Error> for Error {
     fn from(err: data_store::Error) -> Self {
         match err {
             data_store::Error::NotFound(_) => Error::ReferenceNotFound,
+            data_store::Error::PreconditionFailed => Error::Lock("Precondition failed".to_string()),
             _ => Error::DataStore(err),
         }
     }

--- a/src/registry/metadata_store/fs/mod.rs
+++ b/src/registry/metadata_store/fs/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         data_store,
         metadata_store::{
             BlobIndex, BlobIndexOperation, Error, LinkMetadata, LinkOperation, LockConfig,
-            MetadataStore,
+            LockStrategy, MetadataStore,
             link_kind::LinkKind,
             lock::{self, LockBackend, MemoryBackend},
         },
@@ -22,13 +22,49 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BackendConfig {
     pub root_dir: String,
-    #[serde(default)]
-    pub redis: Option<LockConfig>,
-    #[serde(default)]
+    pub lock_strategy: LockStrategy,
     pub sync_to_disk: bool,
+}
+
+impl Default for BackendConfig {
+    fn default() -> Self {
+        Self {
+            root_dir: String::new(),
+            lock_strategy: LockStrategy::Memory,
+            sync_to_disk: false,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BackendConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            root_dir: String,
+            #[serde(default)]
+            redis: Option<LockConfig>,
+            #[serde(default)]
+            lock_strategy: Option<LockStrategy>,
+            #[serde(default)]
+            sync_to_disk: bool,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+
+        let lock_strategy = lock::resolve_lock_strategy(raw.lock_strategy, raw.redis, false)?;
+
+        Ok(BackendConfig {
+            root_dir: raw.root_dir,
+            lock_strategy,
+            sync_to_disk: raw.sync_to_disk,
+        })
+    }
 }
 
 impl From<BackendConfig> for data_store::fs::BackendConfig {
@@ -43,7 +79,7 @@ impl From<BackendConfig> for data_store::fs::BackendConfig {
 #[derive(Clone)]
 pub struct Backend {
     store: data_store::fs::Backend,
-    lock: Arc<dyn LockBackend<Guard = Box<dyn Send>> + Send + Sync>,
+    lock: Arc<dyn LockBackend + Send + Sync>,
 }
 
 impl Backend {
@@ -54,17 +90,24 @@ impl Backend {
             sync_to_disk: config.sync_to_disk,
         });
 
-        let lock: Arc<dyn LockBackend<Guard = Box<dyn Send>> + Send + Sync> =
-            if let Some(redis_config) = &config.redis {
+        let lock: Arc<dyn LockBackend + Send + Sync> = match &config.lock_strategy {
+            LockStrategy::Redis(redis_config) => {
                 info!("Using Redis lock store for filesystem metadata-store");
                 let backend = lock::RedisBackend::new(redis_config).map_err(|e| {
                     Error::Lock(format!("Failed to initialize Redis lock store: {e}"))
                 })?;
                 Arc::new(backend)
-            } else {
+            }
+            LockStrategy::S3(_) => {
+                return Err(Error::Lock(
+                    "S3 lock strategy is not supported for filesystem metadata store".to_string(),
+                ));
+            }
+            LockStrategy::Memory => {
                 info!("Using in-memory lock store for filesystem metadata-store");
                 Arc::new(MemoryBackend::new())
-            };
+            }
+        };
 
         Ok(Self { store, lock })
     }
@@ -324,10 +367,11 @@ impl MetadataStore for Backend {
         update_access_time: bool,
     ) -> Result<LinkMetadata, Error> {
         if update_access_time {
-            let _guard = self.lock.acquire(&[link.to_string()]).await?;
+            let guard = self.lock.acquire(&[link.to_string()]).await?;
             let link_data = self.read_link_reference(namespace, link).await?.accessed();
             self.write_link_reference(namespace, link, &link_data)
                 .await?;
+            guard.release().await;
             Ok(link_data)
         } else {
             self.read_link_reference(namespace, link).await
@@ -416,7 +460,7 @@ impl MetadataStore for Backend {
 
             lock_keys.sort();
             lock_keys.dedup();
-            let _guard = self.lock.acquire(&lock_keys).await?;
+            let guard = self.lock.acquire(&lock_keys).await?;
 
             let validation_results = join_all(creates.iter().map(
                 |(link, _, expected_old, _, _, _)| async move {
@@ -431,12 +475,18 @@ impl MetadataStore for Backend {
                 .iter()
                 .any(|(_, _, current_target, expected)| *current_target != *expected)
             {
+                guard.release().await;
                 continue;
             }
             for (link, metadata, _, _) in validation_results {
                 if let Some(m) = metadata {
                     link_cache.insert(link, m);
                 }
+            }
+
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
             }
 
             let delete_results =
@@ -463,6 +513,7 @@ impl MetadataStore for Backend {
                 }
             }
             if needs_retry {
+                guard.release().await;
                 continue;
             }
 
@@ -515,6 +566,11 @@ impl MetadataStore for Backend {
                     ));
                 }
             }
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
+            }
+
             join_all(
                 non_tracked_create_writes
                     .iter()
@@ -557,6 +613,11 @@ impl MetadataStore for Backend {
                         .push(BlobIndexOperation::Remove(link.clone()));
                 }
             }
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
+            }
+
             join_all(
                 non_tracked_delete_links
                     .iter()
@@ -565,6 +626,11 @@ impl MetadataStore for Backend {
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
+
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
+            }
 
             for (digest, ops) in &pending_blob_ops {
                 let path = path_builder::blob_index_path(digest);
@@ -598,6 +664,12 @@ impl MetadataStore for Backend {
                 }
             }
 
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
+            }
+
+            guard.release().await;
             return Ok(());
         }
     }

--- a/src/registry/metadata_store/fs/mod.rs
+++ b/src/registry/metadata_store/fs/mod.rs
@@ -371,6 +371,11 @@ impl MetadataStore for Backend {
         if update_access_time {
             let guard = self.lock.acquire(&[link.to_string()]).await?;
             let link_data = self.read_link_reference(namespace, link).await?.accessed();
+            if !guard.is_valid() {
+                return Err(Error::Lock(
+                    "lock invalidated during access time update".into(),
+                ));
+            }
             self.write_link_reference(namespace, link, &link_data)
                 .await?;
             guard.release().await;

--- a/src/registry/metadata_store/fs/mod.rs
+++ b/src/registry/metadata_store/fs/mod.rs
@@ -429,6 +429,9 @@ impl MetadataStore for Backend {
             }))
             .await;
 
+            // Lock keys include both link names and `blob:{digest}` for every target digest.
+            // This ensures blob index updates (which perform read-modify-write on per-digest
+            // index files) are serialized across concurrent update_links calls.
             let mut lock_keys: Vec<String> = Vec::new();
             let mut creates: Vec<(
                 LinkKind,
@@ -649,6 +652,10 @@ impl MetadataStore for Backend {
                 return Err(Error::Lock("lock invalidated during operation".into()));
             }
 
+            // Blob index updates for different digests are independent (each digest has its
+            // own file). Updates for the same digest within this call are grouped by the
+            // pending_blob_ops HashMap. Cross-call updates to the same digest are serialized
+            // by the `blob:{digest}` lock key acquired above.
             for (digest, ops) in &pending_blob_ops {
                 let path = path_builder::blob_index_path(digest);
                 let mut blob_index =

--- a/src/registry/metadata_store/fs/mod.rs
+++ b/src/registry/metadata_store/fs/mod.rs
@@ -82,6 +82,8 @@ pub struct Backend {
     lock: Arc<dyn LockBackend + Send + Sync>,
 }
 
+const MAX_UPDATE_RETRIES: u32 = 10;
+
 impl Backend {
     pub fn new(config: &BackendConfig) -> Result<Self, Error> {
         info!("Using filesystem metadata-store backend");
@@ -388,6 +390,7 @@ impl MetadataStore for Backend {
             return Ok(());
         }
 
+        let mut update_retries = MAX_UPDATE_RETRIES;
         loop {
             let mut link_cache: HashMap<LinkKind, LinkMetadata> = HashMap::new();
 
@@ -476,6 +479,13 @@ impl MetadataStore for Backend {
                 .any(|(_, _, current_target, expected)| *current_target != *expected)
             {
                 guard.release().await;
+                if update_retries == 0 {
+                    return Err(Error::Lock(
+                        "update_links exceeded maximum retries due to concurrent modifications"
+                            .into(),
+                    ));
+                }
+                update_retries -= 1;
                 continue;
             }
             for (link, metadata, _, _) in validation_results {
@@ -514,6 +524,13 @@ impl MetadataStore for Backend {
             }
             if needs_retry {
                 guard.release().await;
+                if update_retries == 0 {
+                    return Err(Error::Lock(
+                        "update_links exceeded maximum retries due to concurrent modifications"
+                            .into(),
+                    ));
+                }
+                update_retries -= 1;
                 continue;
             }
 

--- a/src/registry/metadata_store/fs/mod.rs
+++ b/src/registry/metadata_store/fs/mod.rs
@@ -548,7 +548,7 @@ impl MetadataStore for Backend {
             // Non-tracked creates: accumulate blob index ops, then parallel link writes
             let mut non_tracked_create_writes: Vec<(LinkKind, LinkMetadata)> = Vec::new();
             for (link, target, old_target, referrer, media_type, descriptor) in &creates {
-                let is_tracked = is_tracked_link(link);
+                let is_tracked = link.is_tracked();
 
                 if is_tracked && referrer.is_some() {
                     let mut metadata = link_cache.remove(link).unwrap_or_else(|| {
@@ -611,7 +611,7 @@ impl MetadataStore for Backend {
             // Non-tracked deletes: parallel link deletes, then accumulate blob index ops
             let mut non_tracked_delete_links: Vec<LinkKind> = Vec::new();
             for (link, target, referrer) in &valid_deletes {
-                let is_tracked = is_tracked_link(link);
+                let is_tracked = link.is_tracked();
 
                 if is_tracked && referrer.is_some() {
                     if let Some(mut metadata) = link_cache.remove(link) {
@@ -702,13 +702,6 @@ impl MetadataStore for Backend {
             return Ok(());
         }
     }
-}
-
-fn is_tracked_link(link: &LinkKind) -> bool {
-    matches!(
-        link,
-        LinkKind::Layer(_) | LinkKind::Config(_) | LinkKind::Manifest(_, _)
-    )
 }
 
 impl Backend {

--- a/src/registry/metadata_store/link_kind.rs
+++ b/src/registry/metadata_store/link_kind.rs
@@ -14,6 +14,15 @@ pub enum LinkKind {
     Manifest(Digest, Digest),
 }
 
+impl LinkKind {
+    pub fn is_tracked(&self) -> bool {
+        matches!(
+            self,
+            LinkKind::Layer(_) | LinkKind::Config(_) | LinkKind::Manifest(_, _)
+        )
+    }
+}
+
 impl Display for LinkKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/registry/metadata_store/lock/memory/mod.rs
+++ b/src/registry/metadata_store/lock/memory/mod.rs
@@ -13,7 +13,10 @@ use std::{
 use async_trait::async_trait;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
-use crate::registry::metadata_store::{Error, lock::LockBackend};
+use crate::registry::metadata_store::{
+    Error,
+    lock::{LockBackend, LockGuard},
+};
 
 pub struct MemoryGuard {
     _guards: Vec<OwnedMutexGuard<()>>,
@@ -43,18 +46,20 @@ impl MemoryBackend {
 
 #[async_trait]
 impl LockBackend for MemoryBackend {
-    type Guard = Box<dyn Send>;
-
-    async fn acquire(&self, keys: &[String]) -> Result<Self::Guard, Error> {
+    async fn acquire(&self, keys: &[String]) -> Result<LockGuard, Error> {
         let count = self.counter.fetch_add(1, Ordering::Relaxed);
+
+        let mut sorted_keys: Vec<&String> = keys.iter().collect();
+        sorted_keys.sort();
+        sorted_keys.dedup();
 
         let mut locks = self.locks.lock().await;
         if count.is_multiple_of(10000) {
             locks.retain(|_, weak| weak.upgrade().is_some());
         }
 
-        let mut mutexes = Vec::with_capacity(keys.len());
-        for key in keys {
+        let mut mutexes = Vec::with_capacity(sorted_keys.len());
+        for key in sorted_keys {
             let mutex = if let Some(weak) = locks.get(key) {
                 if let Some(lock) = weak.upgrade() {
                     lock
@@ -79,6 +84,6 @@ impl LockBackend for MemoryBackend {
             guards.push(mutex.lock_owned().await);
         }
 
-        Ok(Box::new(MemoryGuard { _guards: guards }))
+        Ok(LockGuard::sync(Box::new(MemoryGuard { _guards: guards })))
     }
 }

--- a/src/registry/metadata_store/lock/memory/mod.rs
+++ b/src/registry/metadata_store/lock/memory/mod.rs
@@ -13,9 +13,12 @@ use std::{
 use async_trait::async_trait;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
-use crate::registry::metadata_store::{
-    Error,
-    lock::{LockBackend, LockGuard},
+use crate::{
+    metrics_provider::{LOCK_ACQUISITION_DURATION, LOCK_ACQUISITIONS},
+    registry::metadata_store::{
+        Error,
+        lock::{LockBackend, LockGuard},
+    },
 };
 
 pub struct MemoryGuard {
@@ -47,6 +50,7 @@ impl MemoryBackend {
 #[async_trait]
 impl LockBackend for MemoryBackend {
     async fn acquire(&self, keys: &[String]) -> Result<LockGuard, Error> {
+        let start = std::time::Instant::now();
         let count = self.counter.fetch_add(1, Ordering::Relaxed);
 
         let mut sorted_keys: Vec<&String> = keys.iter().collect();
@@ -83,6 +87,13 @@ impl LockBackend for MemoryBackend {
         for mutex in mutexes {
             guards.push(mutex.lock_owned().await);
         }
+
+        LOCK_ACQUISITION_DURATION
+            .with_label_values(&["memory"])
+            .observe(start.elapsed().as_secs_f64() * 1000.0);
+        LOCK_ACQUISITIONS
+            .with_label_values(&["memory", "success"])
+            .inc();
 
         Ok(LockGuard::sync(Box::new(MemoryGuard { _guards: guards })))
     }

--- a/src/registry/metadata_store/lock/mod.rs
+++ b/src/registry/metadata_store/lock/mod.rs
@@ -1,18 +1,143 @@
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use async_trait::async_trait;
+use serde::Deserialize;
+use tokio::task::JoinHandle;
+use tracing::warn;
 
 use crate::registry::metadata_store::Error;
 
 pub mod memory;
 pub mod redis;
+pub mod s3;
 
 pub use memory::MemoryBackend;
 pub use redis::RedisBackend;
+pub use s3::S3LockBackend;
+
+type AsyncReleaseFn = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
+
+/// Holds a distributed lock acquired via [`LockBackend::acquire`].
+///
+/// Call [`release()`](Self::release) to explicitly release the lock. If dropped without
+/// calling `release()`, the heartbeat is aborted synchronously and a fire-and-forget async
+/// task is spawned to clean up remote lock objects.
+pub struct LockGuard {
+    sync_guard: Option<Box<dyn Send>>,
+    async_release: Option<AsyncReleaseFn>,
+    valid: Option<Arc<AtomicBool>>,
+    heartbeat_handle: Option<JoinHandle<()>>,
+}
+
+impl LockGuard {
+    pub fn sync(guard: Box<dyn Send>) -> Self {
+        Self {
+            sync_guard: Some(guard),
+            async_release: None,
+            valid: None,
+            heartbeat_handle: None,
+        }
+    }
+
+    pub fn with_async_release(
+        release_fn: impl FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + 'static,
+    ) -> Self {
+        Self {
+            sync_guard: None,
+            async_release: Some(Box::new(release_fn)),
+            valid: None,
+            heartbeat_handle: None,
+        }
+    }
+
+    pub fn with_async_release_and_heartbeat(
+        release_fn: impl FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + 'static,
+        valid: Arc<AtomicBool>,
+        heartbeat_handle: JoinHandle<()>,
+    ) -> Self {
+        Self {
+            sync_guard: None,
+            async_release: Some(Box::new(release_fn)),
+            valid: Some(valid),
+            heartbeat_handle: Some(heartbeat_handle),
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.valid
+            .as_ref()
+            .is_none_or(|v| v.load(Ordering::Acquire))
+    }
+
+    pub async fn release(mut self) {
+        if let Some(handle) = self.heartbeat_handle.take() {
+            handle.abort();
+        }
+        if let Some(release_fn) = self.async_release.take() {
+            release_fn().await;
+        }
+        if let Some(valid) = &self.valid {
+            valid.store(false, Ordering::Release);
+        }
+        drop(self.sync_guard.take());
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.heartbeat_handle.take() {
+            handle.abort();
+        }
+        if let Some(valid) = &self.valid {
+            valid.store(false, Ordering::Release);
+        }
+        if let Some(release_fn) = self.async_release.take() {
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    release_fn().await;
+                });
+            } else {
+                warn!("No tokio runtime available for async lock release on drop");
+            }
+        }
+    }
+}
 
 #[async_trait]
 pub trait LockBackend: Send + Sync + Debug {
-    type Guard: Send;
+    async fn acquire(&self, keys: &[String]) -> Result<LockGuard, Error>;
+}
 
-    async fn acquire(&self, keys: &[String]) -> Result<Self::Guard, Error>;
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum LockStrategy {
+    Memory,
+    Redis(redis::LockConfig),
+    S3(s3::S3LockConfig),
+}
+
+pub fn resolve_lock_strategy<E: serde::de::Error>(
+    lock_strategy: Option<LockStrategy>,
+    redis: Option<redis::LockConfig>,
+    allow_s3: bool,
+) -> Result<LockStrategy, E> {
+    match (lock_strategy, redis) {
+        (Some(_), Some(_)) => Err(E::custom(
+            "cannot set both 'lock_strategy' and 'redis'; use lock_strategy.redis instead",
+        )),
+        (Some(LockStrategy::S3(_)), None) if !allow_s3 => Err(E::custom(
+            "S3 lock strategy is not supported for filesystem metadata store",
+        )),
+        (Some(strategy), None) => Ok(strategy),
+        (None, Some(redis_config)) => Ok(LockStrategy::Redis(redis_config)),
+        (None, None) => Ok(LockStrategy::Memory),
+    }
 }

--- a/src/registry/metadata_store/lock/redis/mod.rs
+++ b/src/registry/metadata_store/lock/redis/mod.rs
@@ -8,7 +8,10 @@ use redis::Client;
 use tokio::{sync::Notify, task::JoinHandle, time::sleep};
 use tracing::debug;
 
-use crate::registry::metadata_store::{Error, lock::LockBackend};
+use crate::registry::metadata_store::{
+    Error,
+    lock::{LockBackend, LockGuard},
+};
 
 const ACQUIRE_SCRIPT: &str = r"
 for i, key in ipairs(KEYS) do
@@ -114,16 +117,14 @@ impl Drop for RedisGuard {
 
 #[async_trait]
 impl LockBackend for RedisBackend {
-    type Guard = Box<dyn Send>;
-
-    async fn acquire(&self, keys: &[String]) -> Result<Self::Guard, Error> {
+    async fn acquire(&self, keys: &[String]) -> Result<LockGuard, Error> {
         if keys.is_empty() {
-            return Ok(Box::new(RedisGuard {
+            return Ok(LockGuard::sync(Box::new(RedisGuard {
                 refresh_handle: tokio::spawn(async {}),
                 stop_notify: Arc::new(Notify::new()),
                 client: self.client.clone(),
                 keys: Vec::new(),
-            }));
+            })));
         }
 
         let lock_keys: Vec<String> = keys
@@ -172,12 +173,12 @@ impl LockBackend for RedisBackend {
                     }
                 });
 
-                return Ok(Box::new(RedisGuard {
+                return Ok(LockGuard::sync(Box::new(RedisGuard {
                     refresh_handle,
                     stop_notify,
                     client: self.client.clone(),
                     keys: lock_keys,
-                }));
+                })));
             }
 
             if retries == 0 {

--- a/src/registry/metadata_store/lock/redis/mod.rs
+++ b/src/registry/metadata_store/lock/redis/mod.rs
@@ -8,9 +8,12 @@ use redis::Client;
 use tokio::{sync::Notify, task::JoinHandle, time::sleep};
 use tracing::debug;
 
-use crate::registry::metadata_store::{
-    Error,
-    lock::{LockBackend, LockGuard},
+use crate::{
+    metrics_provider::{LOCK_ACQUISITION_DURATION, LOCK_ACQUISITIONS, LOCK_RETRIES},
+    registry::metadata_store::{
+        Error,
+        lock::{LockBackend, LockGuard},
+    },
 };
 
 const ACQUIRE_SCRIPT: &str = r"
@@ -127,6 +130,8 @@ impl LockBackend for RedisBackend {
             })));
         }
 
+        let start = std::time::Instant::now();
+
         let lock_keys: Vec<String> = keys
             .iter()
             .map(|k| format!("{}{}", self.key_prefix, k))
@@ -135,14 +140,33 @@ impl LockBackend for RedisBackend {
         let retry_delay = Duration::from_millis(self.retry_delay_ms);
 
         loop {
-            let mut conn = self.client.get_multiplexed_async_connection().await?;
+            let mut conn = self
+                .client
+                .get_multiplexed_async_connection()
+                .await
+                .inspect_err(|_| {
+                    LOCK_ACQUISITION_DURATION
+                        .with_label_values(&["redis"])
+                        .observe(start.elapsed().as_secs_f64() * 1000.0);
+                    LOCK_ACQUISITIONS
+                        .with_label_values(&["redis", "error"])
+                        .inc();
+                })?;
 
             let acquired: i32 = redis::Script::new(ACQUIRE_SCRIPT)
                 .key(&lock_keys)
                 .arg(1)
                 .arg(self.ttl)
                 .invoke_async(&mut conn)
-                .await?;
+                .await
+                .inspect_err(|_| {
+                    LOCK_ACQUISITION_DURATION
+                        .with_label_values(&["redis"])
+                        .observe(start.elapsed().as_secs_f64() * 1000.0);
+                    LOCK_ACQUISITIONS
+                        .with_label_values(&["redis", "error"])
+                        .inc();
+                })?;
 
             if acquired == 1 {
                 let stop_notify = Arc::new(Notify::new());
@@ -173,6 +197,13 @@ impl LockBackend for RedisBackend {
                     }
                 });
 
+                LOCK_ACQUISITION_DURATION
+                    .with_label_values(&["redis"])
+                    .observe(start.elapsed().as_secs_f64() * 1000.0);
+                LOCK_ACQUISITIONS
+                    .with_label_values(&["redis", "success"])
+                    .inc();
+
                 return Ok(LockGuard::sync(Box::new(RedisGuard {
                     refresh_handle,
                     stop_notify,
@@ -182,12 +213,19 @@ impl LockBackend for RedisBackend {
             }
 
             if retries == 0 {
+                LOCK_ACQUISITION_DURATION
+                    .with_label_values(&["redis"])
+                    .observe(start.elapsed().as_secs_f64() * 1000.0);
+                LOCK_ACQUISITIONS
+                    .with_label_values(&["redis", "timeout"])
+                    .inc();
                 return Err(Error::Lock(format!(
                     "Failed to acquire locks for keys: {keys:?}"
                 )));
             }
 
             retries -= 1;
+            LOCK_RETRIES.with_label_values(&["redis"]).inc();
             debug!("Lock busy, retrying... ({} attempts left)", retries);
             tokio::time::sleep(retry_delay).await;
         }

--- a/src/registry/metadata_store/lock/redis/mod.rs
+++ b/src/registry/metadata_store/lock/redis/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 
+// ARGV[1] = instance_id, ARGV[2] = ttl
 const ACQUIRE_SCRIPT: &str = r"
 for i, key in ipairs(KEYS) do
     if redis.call('EXISTS', key) == 1 then
@@ -28,16 +29,22 @@ end
 return 1
 ";
 
+// ARGV[1] = instance_id
 const RELEASE_SCRIPT: &str = r"
 for i, key in ipairs(KEYS) do
-    redis.call('DEL', key)
+    if redis.call('GET', key) == ARGV[1] then
+        redis.call('DEL', key)
+    end
 end
 return 1
 ";
 
+// ARGV[1] = ttl, ARGV[2] = instance_id
 const REFRESH_SCRIPT: &str = r"
 for i, key in ipairs(KEYS) do
-    redis.call('EXPIRE', key, ARGV[1])
+    if redis.call('GET', key) == ARGV[2] then
+        redis.call('EXPIRE', key, ARGV[1])
+    end
 end
 return 1
 ";
@@ -79,6 +86,7 @@ impl Default for LockConfig {
 #[derive(Debug, Clone)]
 pub struct RedisBackend {
     client: Arc<Client>,
+    instance_id: String,
     ttl: usize,
     key_prefix: String,
     max_retries: u32,
@@ -90,11 +98,42 @@ impl RedisBackend {
         let client = Arc::new(Client::open(config.url.clone())?);
         Ok(RedisBackend {
             client,
+            instance_id: uuid::Uuid::new_v4().to_string(),
             ttl: config.ttl,
             key_prefix: config.key_prefix.clone(),
             max_retries: config.max_retries,
             retry_delay_ms: config.retry_delay_ms,
         })
+    }
+
+    fn spawn_refresh_task(&self, keys: Vec<String>) -> (JoinHandle<()>, Arc<Notify>) {
+        let client = self.client.clone();
+        let ttl = self.ttl;
+        let instance_id = self.instance_id.clone();
+        let refresh_interval = Duration::from_secs((ttl / 2) as u64);
+        let stop_notify = Arc::new(Notify::new());
+        let stop_notify_clone = stop_notify.clone();
+
+        let handle = tokio::spawn(async move {
+            let Ok(mut conn) = client.get_multiplexed_async_connection().await else {
+                return;
+            };
+            loop {
+                tokio::select! {
+                    () = sleep(refresh_interval) => {
+                        let _: redis::RedisResult<i32> = redis::Script::new(REFRESH_SCRIPT)
+                            .key(&keys)
+                            .arg(ttl)
+                            .arg(&instance_id)
+                            .invoke_async(&mut conn)
+                            .await;
+                    }
+                    () = stop_notify_clone.notified() => break,
+                }
+            }
+        });
+
+        (handle, stop_notify)
     }
 }
 
@@ -103,6 +142,7 @@ pub struct RedisGuard {
     stop_notify: Arc<Notify>,
     client: Arc<Client>,
     keys: Vec<String>,
+    instance_id: String,
 }
 
 impl Drop for RedisGuard {
@@ -113,6 +153,7 @@ impl Drop for RedisGuard {
         if let Ok(mut conn) = self.client.get_connection() {
             let _: redis::RedisResult<i32> = redis::Script::new(RELEASE_SCRIPT)
                 .key(&self.keys)
+                .arg(&self.instance_id)
                 .invoke(&mut conn);
         }
     }
@@ -127,6 +168,7 @@ impl LockBackend for RedisBackend {
                 stop_notify: Arc::new(Notify::new()),
                 client: self.client.clone(),
                 keys: Vec::new(),
+                instance_id: self.instance_id.clone(),
             })));
         }
 
@@ -155,7 +197,7 @@ impl LockBackend for RedisBackend {
 
             let acquired: i32 = redis::Script::new(ACQUIRE_SCRIPT)
                 .key(&lock_keys)
-                .arg(1)
+                .arg(&self.instance_id)
                 .arg(self.ttl)
                 .invoke_async(&mut conn)
                 .await
@@ -169,33 +211,7 @@ impl LockBackend for RedisBackend {
                 })?;
 
             if acquired == 1 {
-                let stop_notify = Arc::new(Notify::new());
-                let client = self.client.clone();
-                let keys_for_refresh = lock_keys.clone();
-                let ttl = self.ttl;
-                let refresh_interval = Duration::from_secs((ttl / 2) as u64);
-                let stop_notify_clone = stop_notify.clone();
-
-                let refresh_handle = tokio::spawn(async move {
-                    let Ok(mut conn) = client.get_multiplexed_async_connection().await else {
-                        return;
-                    };
-
-                    loop {
-                        tokio::select! {
-                            () = sleep(refresh_interval) => {
-                                let _: redis::RedisResult<i32> = redis::Script::new(REFRESH_SCRIPT)
-                                    .key(&keys_for_refresh)
-                                    .arg(ttl)
-                                    .invoke_async(&mut conn)
-                                    .await;
-                            }
-                            () = stop_notify_clone.notified() => {
-                                break;
-                            }
-                        }
-                    }
-                });
+                let (refresh_handle, stop_notify) = self.spawn_refresh_task(lock_keys.clone());
 
                 LOCK_ACQUISITION_DURATION
                     .with_label_values(&["redis"])
@@ -209,6 +225,7 @@ impl LockBackend for RedisBackend {
                     stop_notify,
                     client: self.client.clone(),
                     keys: lock_keys,
+                    instance_id: self.instance_id.clone(),
                 })));
             }
 

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -1,0 +1,572 @@
+#[cfg(test)]
+mod tests;
+
+use std::{
+    io::ErrorKind,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures_util::future::join_all;
+use serde::{Deserialize, Deserializer, Serialize};
+use tracing::{debug, warn};
+
+use crate::registry::{
+    data_store,
+    metadata_store::{
+        Error,
+        lock::{LockBackend, LockGuard},
+    },
+};
+
+const MAX_LOCK_TTL_SECS: u64 = 3600;
+
+fn deserialize_ttl_secs<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+    let value = u64::deserialize(deserializer)?;
+    if value < 3 {
+        return Err(serde::de::Error::custom(
+            "ttl_secs must be at least 3 (heartbeat runs at ttl/3)",
+        ));
+    }
+    Ok(value)
+}
+
+fn deserialize_retry_delay_ms<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+    let value = u64::deserialize(deserializer)?;
+    if value < 1 {
+        return Err(serde::de::Error::custom(
+            "retry_delay_ms must be at least 1",
+        ));
+    }
+    Ok(value)
+}
+
+fn deserialize_max_hold_secs<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+    let value = u64::deserialize(deserializer)?;
+    if value < 10 {
+        return Err(serde::de::Error::custom(
+            "max_hold_secs must be at least 10",
+        ));
+    }
+    Ok(value)
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct S3LockConfig {
+    #[serde(
+        default = "S3LockConfig::default_ttl_secs",
+        deserialize_with = "deserialize_ttl_secs"
+    )]
+    pub ttl_secs: u64,
+    #[serde(default = "S3LockConfig::default_max_retries")]
+    pub max_retries: u32,
+    #[serde(
+        default = "S3LockConfig::default_retry_delay_ms",
+        deserialize_with = "deserialize_retry_delay_ms"
+    )]
+    pub retry_delay_ms: u64,
+    #[serde(
+        default = "S3LockConfig::default_max_hold_secs",
+        deserialize_with = "deserialize_max_hold_secs"
+    )]
+    pub max_hold_secs: u64,
+}
+
+impl S3LockConfig {
+    fn default_ttl_secs() -> u64 {
+        30
+    }
+
+    fn default_max_retries() -> u32 {
+        100
+    }
+
+    fn default_retry_delay_ms() -> u64 {
+        50
+    }
+
+    fn default_max_hold_secs() -> u64 {
+        300
+    }
+}
+
+impl Default for S3LockConfig {
+    fn default() -> Self {
+        Self {
+            ttl_secs: Self::default_ttl_secs(),
+            max_retries: Self::default_max_retries(),
+            retry_delay_ms: Self::default_retry_delay_ms(),
+            max_hold_secs: Self::default_max_hold_secs(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct S3LockPayload {
+    instance_id: String,
+    refreshed_at: DateTime<Utc>,
+    ttl_secs: u64,
+}
+
+impl S3LockPayload {
+    // Uses S3's LastModified timestamp (set by the S3 server) instead of the embedded
+    // refreshed_at field (set by the requesting instance) to eliminate inter-instance
+    // clock skew. The refreshed_at field is retained for debugging and logging.
+    fn is_expired(&self, last_modified: DateTime<Utc>) -> bool {
+        let effective_ttl = self.ttl_secs.min(MAX_LOCK_TTL_SECS);
+        let expiry = last_modified + chrono::Duration::seconds(effective_ttl.cast_signed());
+        Utc::now() > expiry
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct S3LockBackend {
+    store: Arc<data_store::s3::Backend>,
+    instance_id: String,
+    ttl_secs: u64,
+    max_hold_secs: u64,
+    max_retries: u32,
+    retry_delay_ms: u64,
+}
+
+impl S3LockBackend {
+    pub fn new(store: Arc<data_store::s3::Backend>, config: &S3LockConfig) -> Result<Self, Error> {
+        if config.ttl_secs < 3 {
+            return Err(Error::InvalidData("ttl_secs must be at least 3".into()));
+        }
+        if config.retry_delay_ms < 1 {
+            return Err(Error::InvalidData(
+                "retry_delay_ms must be at least 1".into(),
+            ));
+        }
+        if config.max_hold_secs < config.ttl_secs {
+            return Err(Error::InvalidData(
+                "max_hold_secs must be >= ttl_secs".into(),
+            ));
+        }
+        Ok(Self {
+            store,
+            instance_id: uuid::Uuid::new_v4().to_string(),
+            ttl_secs: config.ttl_secs,
+            max_hold_secs: config.max_hold_secs,
+            max_retries: config.max_retries,
+            retry_delay_ms: config.retry_delay_ms,
+        })
+    }
+
+    fn lock_path(key: &str) -> String {
+        format!("_locks/{key}")
+    }
+
+    fn jittered_delay(&self, attempt: u32) -> Duration {
+        let max_delay_ms: u64 = 1000;
+        let base_ms = self.retry_delay_ms.saturating_mul(1u64 << attempt.min(6));
+        let jitter = simple_jitter(base_ms.min(max_delay_ms) / 2);
+        let total_ms = base_ms.saturating_add(jitter).min(max_delay_ms);
+        Duration::from_millis(total_ms)
+    }
+
+    fn make_payload(&self) -> Vec<u8> {
+        let payload = S3LockPayload {
+            instance_id: self.instance_id.clone(),
+            refreshed_at: Utc::now(),
+            ttl_secs: self.ttl_secs,
+        };
+        serde_json::to_vec(&payload).expect("lock payload serialization cannot fail")
+    }
+
+    fn make_guard(&self, lock_paths: Vec<String>) -> LockGuard {
+        let valid = Arc::new(AtomicBool::new(true));
+        let heartbeat_handle = self.spawn_heartbeat(lock_paths.clone(), valid.clone());
+        let store = self.store.clone();
+        let instance_id = self.instance_id.clone();
+        let valid_for_release = valid.clone();
+        LockGuard::with_async_release_and_heartbeat(
+            move || {
+                Box::pin(async move {
+                    if !valid_for_release.load(Ordering::Acquire) {
+                        debug!("Lock ownership lost, skipping delete on release");
+                        return;
+                    }
+                    let futs: Vec<_> = lock_paths
+                        .iter()
+                        .map(|path| {
+                            let store = store.clone();
+                            let path = path.clone();
+                            let instance_id = instance_id.clone();
+                            async move {
+                                match store.read_with_etag(&path).await {
+                                    Ok((data, _)) => {
+                                        match serde_json::from_slice::<S3LockPayload>(&data) {
+                                            Ok(payload) if payload.instance_id == instance_id => {
+                                                if let Err(e) = store.delete(&path).await {
+                                                    warn!(
+                                                        path,
+                                                        error = %e,
+                                                        "Failed to delete lock on release"
+                                                    );
+                                                }
+                                            }
+                                            Ok(payload) => {
+                                                debug!(
+                                                    path,
+                                                    expected = instance_id,
+                                                    found = payload.instance_id,
+                                                    "Lock ownership changed, skipping delete"
+                                                );
+                                            }
+                                            Err(e) => {
+                                                warn!(
+                                                    path,
+                                                    error = %e,
+                                                    "Failed to deserialize lock payload on release, skipping delete"
+                                                );
+                                            }
+                                        }
+                                    }
+                                    Err(e) if e.kind() == ErrorKind::NotFound => {
+                                        debug!(path, "Lock already deleted");
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            path,
+                                            error = %e,
+                                            "Failed to read lock for ownership check on release, skipping delete"
+                                        );
+                                    }
+                                }
+                            }
+                        })
+                        .collect();
+                    join_all(futs).await;
+                })
+            },
+            valid,
+            heartbeat_handle,
+        )
+    }
+
+    async fn try_acquire_key(&self, lock_path: &str) -> Result<bool, Error> {
+        let payload = self.make_payload();
+        match self
+            .store
+            .put_object_if_not_exists(lock_path, payload)
+            .await
+        {
+            Ok(()) => Ok(true),
+            Err(data_store::Error::PreconditionFailed) => Ok(false),
+            Err(e) => Err(Error::StorageBackend(e.to_string())),
+        }
+    }
+
+    async fn try_recover_stale_lock(&self, lock_path: &str) -> RecoveryOutcome {
+        let (data, etag, last_modified) = match self.store.read_with_metadata(lock_path).await {
+            Ok(result) => result,
+            Err(e) if e.kind() == ErrorKind::NotFound => return RecoveryOutcome::Retry,
+            Err(e) => return RecoveryOutcome::Error(e.to_string()),
+        };
+
+        let payload: S3LockPayload = match serde_json::from_slice(&data) {
+            Ok(p) => p,
+            Err(e) => return RecoveryOutcome::Error(format!("corrupt lock payload: {e}")),
+        };
+
+        let last_modified = last_modified.unwrap_or(payload.refreshed_at);
+        if !payload.is_expired(last_modified) {
+            return RecoveryOutcome::NotStale;
+        }
+
+        debug!(
+            lock_path,
+            instance_id = payload.instance_id,
+            refreshed_at = %payload.refreshed_at,
+            "Recovering stale lock"
+        );
+
+        let Some(etag) = etag else {
+            return RecoveryOutcome::Error("lock object missing ETag".to_string());
+        };
+
+        match self
+            .store
+            .put_object_if_match(lock_path, &etag, self.make_payload())
+            .await
+        {
+            Ok(()) => RecoveryOutcome::Acquired,
+            Err(data_store::Error::PreconditionFailed) => RecoveryOutcome::Failed,
+            Err(e) => RecoveryOutcome::Error(e.to_string()),
+        }
+    }
+
+    async fn release_paths(&self, paths: &[String]) {
+        let futs: Vec<_> = paths
+            .iter()
+            .map(|path| async move {
+                if let Err(e) = self.store.delete(path).await {
+                    warn!(path, error = %e, "Failed to delete lock path during rollback");
+                }
+            })
+            .collect();
+        join_all(futs).await;
+    }
+
+    fn spawn_heartbeat(
+        &self,
+        paths: Vec<String>,
+        valid: Arc<AtomicBool>,
+    ) -> tokio::task::JoinHandle<()> {
+        let store = self.store.clone();
+        let instance_id = self.instance_id.clone();
+        let ttl_secs = self.ttl_secs;
+        let max_hold_secs = self.max_hold_secs;
+        let interval = Duration::from_secs(ttl_secs / 3);
+
+        tokio::spawn(async move {
+            let started_at = tokio::time::Instant::now();
+            let max_hold = Duration::from_secs(max_hold_secs);
+            let mut interval_timer = tokio::time::interval(interval);
+            interval_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            interval_timer.tick().await; // consume immediate first tick
+
+            let mut consecutive_failures: u32 = 0;
+
+            loop {
+                interval_timer.tick().await;
+
+                if started_at.elapsed() >= max_hold {
+                    warn!(
+                        max_hold_secs,
+                        "Lock held beyond maximum duration, invalidating"
+                    );
+                    valid.store(false, Ordering::Release);
+                    return;
+                }
+
+                let mut tick_had_failure = false;
+
+                for path in &paths {
+                    let etag = match store.read_with_etag(path).await {
+                        Ok((data, etag)) => {
+                            if let Ok(existing) = serde_json::from_slice::<S3LockPayload>(&data)
+                                && existing.instance_id != instance_id
+                            {
+                                warn!(
+                                    path,
+                                    expected = instance_id,
+                                    found = existing.instance_id,
+                                    "Lock ownership lost, stopping heartbeat"
+                                );
+                                valid.store(false, Ordering::Release);
+                                return;
+                            }
+                            etag
+                        }
+                        Err(e) if e.kind() == ErrorKind::NotFound => {
+                            warn!(path, "Lock file disappeared, stopping heartbeat");
+                            valid.store(false, Ordering::Release);
+                            return;
+                        }
+                        Err(e) => {
+                            warn!(path, error = %e, "Failed to read lock for heartbeat");
+                            tick_had_failure = true;
+                            continue;
+                        }
+                    };
+
+                    let Some(etag) = etag else {
+                        warn!(
+                            path,
+                            "Lock ETag unavailable, cannot safely refresh heartbeat, invalidating lock"
+                        );
+                        valid.store(false, Ordering::Release);
+                        return;
+                    };
+
+                    let payload = S3LockPayload {
+                        instance_id: instance_id.clone(),
+                        refreshed_at: Utc::now(),
+                        ttl_secs,
+                    };
+                    let data = serde_json::to_vec(&payload)
+                        .expect("lock payload serialization cannot fail");
+
+                    match store.put_object_if_match(path, &etag, data).await {
+                        Ok(()) => {
+                            debug!(path, "Refreshed S3 lock heartbeat");
+                        }
+                        Err(data_store::Error::PreconditionFailed) => {
+                            warn!(
+                                path,
+                                "Lock ETag changed, ownership lost, stopping heartbeat"
+                            );
+                            valid.store(false, Ordering::Release);
+                            return;
+                        }
+                        Err(e) => {
+                            warn!(path, error = %e, "Failed to refresh S3 lock heartbeat");
+                            tick_had_failure = true;
+                        }
+                    }
+                }
+
+                if tick_had_failure {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
+                    if u64::from(consecutive_failures) * (ttl_secs / 3) >= ttl_secs {
+                        warn!(
+                            consecutive_failures,
+                            "Too many consecutive heartbeat tick failures, invalidating lock"
+                        );
+                        valid.store(false, Ordering::Release);
+                        return;
+                    }
+                } else {
+                    consecutive_failures = 0;
+                }
+            }
+        })
+    }
+}
+
+#[cfg_attr(test, derive(Debug))]
+enum RecoveryOutcome {
+    Acquired,
+    NotStale,
+    Retry,
+    Failed,
+    Error(String),
+}
+
+fn simple_jitter(max_ms: u64) -> u64 {
+    use std::hash::{BuildHasher, Hasher};
+    if max_ms == 0 {
+        return 0;
+    }
+    std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish()
+        % max_ms
+}
+
+#[cfg(test)]
+impl S3LockBackend {
+    async fn test_try_recover(&self, key: &str) -> RecoveryOutcome {
+        self.try_recover_stale_lock(&Self::lock_path(key)).await
+    }
+}
+
+#[async_trait]
+impl LockBackend for S3LockBackend {
+    async fn acquire(&self, keys: &[String]) -> Result<LockGuard, Error> {
+        if keys.is_empty() {
+            return Ok(LockGuard::with_async_release(|| Box::pin(async {})));
+        }
+
+        let mut lock_paths: Vec<String> = keys.iter().map(|k| Self::lock_path(k)).collect();
+        lock_paths.sort();
+        lock_paths.dedup();
+
+        let mut retries = self.max_retries;
+
+        loop {
+            let results: Vec<(usize, Result<bool, Error>)> = {
+                let futs: Vec<_> = lock_paths
+                    .iter()
+                    .enumerate()
+                    .map(|(i, path)| {
+                        let path = path.clone();
+                        async move { (i, self.try_acquire_key(&path).await) }
+                    })
+                    .collect();
+                // Parallel PUTs with overlapping key sets across instances can cause
+                // repeated rollbacks (practical livelock). Sorted key order prevents
+                // circular wait in sequential protocols but does not prevent collision
+                // in a parallel-issue protocol. The retry budget (`max_retries`) bounds
+                // total attempts. Randomized jitter (simple_jitter) desynchronises
+                // retrying instances to break collision patterns.
+                join_all(futs).await
+            };
+
+            let mut acquired_paths = Vec::new();
+            let mut failed = false;
+            let mut hard_error: Option<Error> = None;
+
+            for (i, result) in &results {
+                match result {
+                    Ok(true) => acquired_paths.push(lock_paths[*i].clone()),
+                    Ok(false) => failed = true,
+                    Err(e) => {
+                        hard_error = Some(Error::StorageBackend(format!("S3 lock error: {e}")));
+                        failed = true;
+                    }
+                }
+            }
+
+            if !failed {
+                return Ok(self.make_guard(lock_paths));
+            }
+
+            if let Some(e) = hard_error {
+                self.release_paths(&acquired_paths).await;
+                return Err(e);
+            }
+
+            let recovery_futs: Vec<_> = results
+                .iter()
+                .filter(|(_, result)| matches!(result, Ok(false)))
+                .map(|(i, _)| {
+                    let path = lock_paths[*i].clone();
+                    async move { (i, self.try_recover_stale_lock(&path).await) }
+                })
+                .collect();
+
+            let recovery_results = join_all(recovery_futs).await;
+
+            let mut recovered_paths = Vec::new();
+            for (i, outcome) in recovery_results {
+                match outcome {
+                    RecoveryOutcome::Acquired => {
+                        recovered_paths.push(lock_paths[*i].clone());
+                    }
+                    RecoveryOutcome::Error(msg) => {
+                        self.release_paths(&acquired_paths).await;
+                        if !recovered_paths.is_empty() {
+                            self.release_paths(&recovered_paths).await;
+                        }
+                        return Err(Error::StorageBackend(format!(
+                            "S3 lock recovery error: {msg}"
+                        )));
+                    }
+                    RecoveryOutcome::Failed
+                    | RecoveryOutcome::NotStale
+                    | RecoveryOutcome::Retry => {}
+                }
+            }
+
+            if recovered_paths.len() + acquired_paths.len() == lock_paths.len() {
+                return Ok(self.make_guard(lock_paths));
+            }
+
+            self.release_paths(&acquired_paths).await;
+            if !recovered_paths.is_empty() {
+                self.release_paths(&recovered_paths).await;
+            }
+
+            if retries == 0 {
+                return Err(Error::Lock(format!(
+                    "Failed to acquire S3 locks after {} attempts for keys: {:?}",
+                    self.max_retries, keys
+                )));
+            }
+
+            retries -= 1;
+            let attempt = self.max_retries - retries;
+            debug!(retries_left = retries, "S3 lock busy, retrying...");
+            tokio::time::sleep(self.jittered_delay(attempt)).await;
+        }
+    }
+}

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -16,11 +16,17 @@ use futures_util::future::join_all;
 use serde::{Deserialize, Deserializer, Serialize};
 use tracing::{debug, warn};
 
-use crate::registry::{
-    data_store,
-    metadata_store::{
-        Error,
-        lock::{LockBackend, LockGuard},
+use crate::{
+    metrics_provider::{
+        LOCK_ACQUISITION_DURATION, LOCK_ACQUISITIONS, LOCK_INVALIDATIONS, LOCK_RECOVERIES,
+        LOCK_RETRIES,
+    },
+    registry::{
+        data_store,
+        metadata_store::{
+            Error,
+            lock::{LockBackend, LockGuard},
+        },
     },
 };
 
@@ -288,17 +294,31 @@ impl S3LockBackend {
     async fn try_recover_stale_lock(&self, lock_path: &str) -> RecoveryOutcome {
         let (data, etag, last_modified) = match self.store.read_with_metadata(lock_path).await {
             Ok(result) => result,
-            Err(e) if e.kind() == ErrorKind::NotFound => return RecoveryOutcome::Retry,
-            Err(e) => return RecoveryOutcome::Error(e.to_string()),
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                LOCK_RECOVERIES
+                    .with_label_values(&["s3", "not_stale"])
+                    .inc();
+                return RecoveryOutcome::Retry;
+            }
+            Err(e) => {
+                LOCK_RECOVERIES.with_label_values(&["s3", "error"]).inc();
+                return RecoveryOutcome::Error(e.to_string());
+            }
         };
 
         let payload: S3LockPayload = match serde_json::from_slice(&data) {
             Ok(p) => p,
-            Err(e) => return RecoveryOutcome::Error(format!("corrupt lock payload: {e}")),
+            Err(e) => {
+                LOCK_RECOVERIES.with_label_values(&["s3", "error"]).inc();
+                return RecoveryOutcome::Error(format!("corrupt lock payload: {e}"));
+            }
         };
 
         let last_modified = last_modified.unwrap_or(payload.refreshed_at);
         if !payload.is_expired(last_modified) {
+            LOCK_RECOVERIES
+                .with_label_values(&["s3", "not_stale"])
+                .inc();
             return RecoveryOutcome::NotStale;
         }
 
@@ -310,6 +330,7 @@ impl S3LockBackend {
         );
 
         let Some(etag) = etag else {
+            LOCK_RECOVERIES.with_label_values(&["s3", "error"]).inc();
             return RecoveryOutcome::Error("lock object missing ETag".to_string());
         };
 
@@ -318,9 +339,18 @@ impl S3LockBackend {
             .put_object_if_match(lock_path, &etag, self.make_payload())
             .await
         {
-            Ok(()) => RecoveryOutcome::Acquired,
-            Err(data_store::Error::PreconditionFailed) => RecoveryOutcome::Failed,
-            Err(e) => RecoveryOutcome::Error(e.to_string()),
+            Ok(()) => {
+                LOCK_RECOVERIES.with_label_values(&["s3", "acquired"]).inc();
+                RecoveryOutcome::Acquired
+            }
+            Err(data_store::Error::PreconditionFailed) => {
+                LOCK_RECOVERIES.with_label_values(&["s3", "failed"]).inc();
+                RecoveryOutcome::Failed
+            }
+            Err(e) => {
+                LOCK_RECOVERIES.with_label_values(&["s3", "error"]).inc();
+                RecoveryOutcome::Error(e.to_string())
+            }
         }
     }
 
@@ -364,72 +394,23 @@ impl S3LockBackend {
                         max_hold_secs,
                         "Lock held beyond maximum duration, invalidating"
                     );
+                    LOCK_INVALIDATIONS
+                        .with_label_values(&["s3", "max_hold"])
+                        .inc();
                     valid.store(false, Ordering::Release);
                     return;
                 }
 
                 let mut tick_had_failure = false;
-
                 for path in &paths {
-                    let etag = match store.read_with_etag(path).await {
-                        Ok((data, etag)) => {
-                            if let Ok(existing) = serde_json::from_slice::<S3LockPayload>(&data)
-                                && existing.instance_id != instance_id
-                            {
-                                warn!(
-                                    path,
-                                    expected = instance_id,
-                                    found = existing.instance_id,
-                                    "Lock ownership lost, stopping heartbeat"
-                                );
-                                valid.store(false, Ordering::Release);
-                                return;
-                            }
-                            etag
-                        }
-                        Err(e) if e.kind() == ErrorKind::NotFound => {
-                            warn!(path, "Lock file disappeared, stopping heartbeat");
+                    match heartbeat_tick_path(&store, path, &instance_id, ttl_secs).await {
+                        HeartbeatPathResult::Ok => {}
+                        HeartbeatPathResult::Invalidate(reason) => {
+                            LOCK_INVALIDATIONS.with_label_values(&["s3", reason]).inc();
                             valid.store(false, Ordering::Release);
                             return;
                         }
-                        Err(e) => {
-                            warn!(path, error = %e, "Failed to read lock for heartbeat");
-                            tick_had_failure = true;
-                            continue;
-                        }
-                    };
-
-                    let Some(etag) = etag else {
-                        warn!(
-                            path,
-                            "Lock ETag unavailable, cannot safely refresh heartbeat, invalidating lock"
-                        );
-                        valid.store(false, Ordering::Release);
-                        return;
-                    };
-
-                    let payload = S3LockPayload {
-                        instance_id: instance_id.clone(),
-                        refreshed_at: Utc::now(),
-                        ttl_secs,
-                    };
-                    let data = serde_json::to_vec(&payload)
-                        .expect("lock payload serialization cannot fail");
-
-                    match store.put_object_if_match(path, &etag, data).await {
-                        Ok(()) => {
-                            debug!(path, "Refreshed S3 lock heartbeat");
-                        }
-                        Err(data_store::Error::PreconditionFailed) => {
-                            warn!(
-                                path,
-                                "Lock ETag changed, ownership lost, stopping heartbeat"
-                            );
-                            valid.store(false, Ordering::Release);
-                            return;
-                        }
-                        Err(e) => {
-                            warn!(path, error = %e, "Failed to refresh S3 lock heartbeat");
+                        HeartbeatPathResult::Failure => {
                             tick_had_failure = true;
                         }
                     }
@@ -442,6 +423,9 @@ impl S3LockBackend {
                             consecutive_failures,
                             "Too many consecutive heartbeat tick failures, invalidating lock"
                         );
+                        LOCK_INVALIDATIONS
+                            .with_label_values(&["s3", "heartbeat_failure"])
+                            .inc();
                         valid.store(false, Ordering::Release);
                         return;
                     }
@@ -450,6 +434,77 @@ impl S3LockBackend {
                 }
             }
         })
+    }
+}
+
+enum HeartbeatPathResult {
+    Ok,
+    Invalidate(&'static str),
+    Failure,
+}
+
+async fn heartbeat_tick_path(
+    store: &data_store::s3::Backend,
+    path: &str,
+    instance_id: &str,
+    ttl_secs: u64,
+) -> HeartbeatPathResult {
+    let etag = match store.read_with_etag(path).await {
+        Ok((data, etag)) => {
+            if let Ok(existing) = serde_json::from_slice::<S3LockPayload>(&data)
+                && existing.instance_id != instance_id
+            {
+                warn!(
+                    path,
+                    expected = instance_id,
+                    found = existing.instance_id,
+                    "Lock ownership lost, stopping heartbeat"
+                );
+                return HeartbeatPathResult::Invalidate("ownership_lost");
+            }
+            etag
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            warn!(path, "Lock file disappeared, stopping heartbeat");
+            return HeartbeatPathResult::Invalidate("file_disappeared");
+        }
+        Err(e) => {
+            warn!(path, error = %e, "Failed to read lock for heartbeat");
+            return HeartbeatPathResult::Failure;
+        }
+    };
+
+    let Some(etag) = etag else {
+        warn!(
+            path,
+            "Lock ETag unavailable, cannot safely refresh heartbeat, invalidating lock"
+        );
+        return HeartbeatPathResult::Invalidate("etag_unavailable");
+    };
+
+    let payload = S3LockPayload {
+        instance_id: instance_id.to_owned(),
+        refreshed_at: Utc::now(),
+        ttl_secs,
+    };
+    let data = serde_json::to_vec(&payload).expect("lock payload serialization cannot fail");
+
+    match store.put_object_if_match(path, &etag, data).await {
+        Ok(()) => {
+            debug!(path, "Refreshed S3 lock heartbeat");
+            HeartbeatPathResult::Ok
+        }
+        Err(data_store::Error::PreconditionFailed) => {
+            warn!(
+                path,
+                "Lock ETag changed, ownership lost, stopping heartbeat"
+            );
+            HeartbeatPathResult::Invalidate("ownership_lost")
+        }
+        Err(e) => {
+            warn!(path, error = %e, "Failed to refresh S3 lock heartbeat");
+            HeartbeatPathResult::Failure
+        }
     }
 }
 
@@ -480,12 +535,101 @@ impl S3LockBackend {
     }
 }
 
+enum AcquireRoundOutcome {
+    AllAcquired,
+    HardError(Error),
+    RecoveryError {
+        msg: String,
+        to_release: Vec<String>,
+    },
+    Retry {
+        acquired: Vec<String>,
+        recovered: Vec<String>,
+    },
+}
+
+impl S3LockBackend {
+    async fn try_acquire_round(&self, lock_paths: &[String]) -> AcquireRoundOutcome {
+        // Parallel PUTs with overlapping key sets across instances can cause
+        // repeated rollbacks (practical livelock). Sorted key order prevents
+        // circular wait in sequential protocols but does not prevent collision
+        // in a parallel-issue protocol. The retry budget (`max_retries`) bounds
+        // total attempts. Randomized jitter (simple_jitter) desynchronises
+        // retrying instances to break collision patterns.
+        let futs: Vec<_> = lock_paths
+            .iter()
+            .enumerate()
+            .map(|(i, path)| {
+                let path = path.clone();
+                async move { (i, self.try_acquire_key(&path).await) }
+            })
+            .collect();
+        let results: Vec<(usize, Result<bool, Error>)> = join_all(futs).await;
+
+        let mut acquired_paths = Vec::new();
+        let mut failed_indices = Vec::new();
+        let mut hard_error: Option<Error> = None;
+
+        for (i, result) in &results {
+            match result {
+                Ok(true) => acquired_paths.push(lock_paths[*i].clone()),
+                Ok(false) => failed_indices.push(*i),
+                Err(e) => {
+                    hard_error = Some(Error::StorageBackend(format!("S3 lock error: {e}")));
+                    break;
+                }
+            }
+        }
+
+        if let Some(e) = hard_error {
+            self.release_paths(&acquired_paths).await;
+            return AcquireRoundOutcome::HardError(e);
+        }
+
+        if failed_indices.is_empty() {
+            return AcquireRoundOutcome::AllAcquired;
+        }
+
+        let recovery_futs: Vec<_> = failed_indices
+            .iter()
+            .map(|&i| {
+                let path = lock_paths[i].clone();
+                async move { (i, self.try_recover_stale_lock(&path).await) }
+            })
+            .collect();
+
+        let mut recovered_paths = Vec::new();
+        for (i, outcome) in join_all(recovery_futs).await {
+            match outcome {
+                RecoveryOutcome::Acquired => recovered_paths.push(lock_paths[i].clone()),
+                RecoveryOutcome::Error(msg) => {
+                    let mut to_release = acquired_paths;
+                    to_release.extend(recovered_paths);
+                    return AcquireRoundOutcome::RecoveryError { msg, to_release };
+                }
+                RecoveryOutcome::Failed | RecoveryOutcome::NotStale | RecoveryOutcome::Retry => {}
+            }
+        }
+
+        if recovered_paths.len() + acquired_paths.len() == lock_paths.len() {
+            return AcquireRoundOutcome::AllAcquired;
+        }
+
+        AcquireRoundOutcome::Retry {
+            acquired: acquired_paths,
+            recovered: recovered_paths,
+        }
+    }
+}
+
 #[async_trait]
 impl LockBackend for S3LockBackend {
     async fn acquire(&self, keys: &[String]) -> Result<LockGuard, Error> {
         if keys.is_empty() {
             return Ok(LockGuard::with_async_release(|| Box::pin(async {})));
         }
+
+        let start = std::time::Instant::now();
 
         let mut lock_paths: Vec<String> = keys.iter().map(|k| Self::lock_path(k)).collect();
         lock_paths.sort();
@@ -494,100 +638,60 @@ impl LockBackend for S3LockBackend {
         let mut retries = self.max_retries;
 
         loop {
-            let results: Vec<(usize, Result<bool, Error>)> = {
-                let futs: Vec<_> = lock_paths
-                    .iter()
-                    .enumerate()
-                    .map(|(i, path)| {
-                        let path = path.clone();
-                        async move { (i, self.try_acquire_key(&path).await) }
-                    })
-                    .collect();
-                // Parallel PUTs with overlapping key sets across instances can cause
-                // repeated rollbacks (practical livelock). Sorted key order prevents
-                // circular wait in sequential protocols but does not prevent collision
-                // in a parallel-issue protocol. The retry budget (`max_retries`) bounds
-                // total attempts. Randomized jitter (simple_jitter) desynchronises
-                // retrying instances to break collision patterns.
-                join_all(futs).await
-            };
-
-            let mut acquired_paths = Vec::new();
-            let mut failed = false;
-            let mut hard_error: Option<Error> = None;
-
-            for (i, result) in &results {
-                match result {
-                    Ok(true) => acquired_paths.push(lock_paths[*i].clone()),
-                    Ok(false) => failed = true,
-                    Err(e) => {
-                        hard_error = Some(Error::StorageBackend(format!("S3 lock error: {e}")));
-                        failed = true;
-                    }
+            match self.try_acquire_round(&lock_paths).await {
+                AcquireRoundOutcome::AllAcquired => {
+                    LOCK_ACQUISITION_DURATION
+                        .with_label_values(&["s3"])
+                        .observe(start.elapsed().as_secs_f64() * 1000.0);
+                    LOCK_ACQUISITIONS
+                        .with_label_values(&["s3", "success"])
+                        .inc();
+                    return Ok(self.make_guard(lock_paths));
                 }
-            }
-
-            if !failed {
-                return Ok(self.make_guard(lock_paths));
-            }
-
-            if let Some(e) = hard_error {
-                self.release_paths(&acquired_paths).await;
-                return Err(e);
-            }
-
-            let recovery_futs: Vec<_> = results
-                .iter()
-                .filter(|(_, result)| matches!(result, Ok(false)))
-                .map(|(i, _)| {
-                    let path = lock_paths[*i].clone();
-                    async move { (i, self.try_recover_stale_lock(&path).await) }
-                })
-                .collect();
-
-            let recovery_results = join_all(recovery_futs).await;
-
-            let mut recovered_paths = Vec::new();
-            for (i, outcome) in recovery_results {
-                match outcome {
-                    RecoveryOutcome::Acquired => {
-                        recovered_paths.push(lock_paths[*i].clone());
+                AcquireRoundOutcome::HardError(e) => {
+                    LOCK_ACQUISITION_DURATION
+                        .with_label_values(&["s3"])
+                        .observe(start.elapsed().as_secs_f64() * 1000.0);
+                    LOCK_ACQUISITIONS.with_label_values(&["s3", "error"]).inc();
+                    return Err(e);
+                }
+                AcquireRoundOutcome::RecoveryError { msg, to_release } => {
+                    self.release_paths(&to_release).await;
+                    LOCK_ACQUISITION_DURATION
+                        .with_label_values(&["s3"])
+                        .observe(start.elapsed().as_secs_f64() * 1000.0);
+                    LOCK_ACQUISITIONS.with_label_values(&["s3", "error"]).inc();
+                    return Err(Error::StorageBackend(format!(
+                        "S3 lock recovery error: {msg}"
+                    )));
+                }
+                AcquireRoundOutcome::Retry {
+                    acquired,
+                    recovered,
+                } => {
+                    self.release_paths(&acquired).await;
+                    if !recovered.is_empty() {
+                        self.release_paths(&recovered).await;
                     }
-                    RecoveryOutcome::Error(msg) => {
-                        self.release_paths(&acquired_paths).await;
-                        if !recovered_paths.is_empty() {
-                            self.release_paths(&recovered_paths).await;
-                        }
-                        return Err(Error::StorageBackend(format!(
-                            "S3 lock recovery error: {msg}"
+                    if retries == 0 {
+                        LOCK_ACQUISITION_DURATION
+                            .with_label_values(&["s3"])
+                            .observe(start.elapsed().as_secs_f64() * 1000.0);
+                        LOCK_ACQUISITIONS
+                            .with_label_values(&["s3", "timeout"])
+                            .inc();
+                        return Err(Error::Lock(format!(
+                            "Failed to acquire S3 locks after {} attempts for keys: {:?}",
+                            self.max_retries, keys
                         )));
                     }
-                    RecoveryOutcome::Failed
-                    | RecoveryOutcome::NotStale
-                    | RecoveryOutcome::Retry => {}
+                    retries -= 1;
+                    let attempt = self.max_retries - retries;
+                    LOCK_RETRIES.with_label_values(&["s3"]).inc();
+                    debug!(retries_left = retries, "S3 lock busy, retrying...");
+                    tokio::time::sleep(self.jittered_delay(attempt)).await;
                 }
             }
-
-            if recovered_paths.len() + acquired_paths.len() == lock_paths.len() {
-                return Ok(self.make_guard(lock_paths));
-            }
-
-            self.release_paths(&acquired_paths).await;
-            if !recovered_paths.is_empty() {
-                self.release_paths(&recovered_paths).await;
-            }
-
-            if retries == 0 {
-                return Err(Error::Lock(format!(
-                    "Failed to acquire S3 locks after {} attempts for keys: {:?}",
-                    self.max_retries, keys
-                )));
-            }
-
-            retries -= 1;
-            let attempt = self.max_retries - retries;
-            debug!(retries_left = retries, "S3 lock busy, retrying...");
-            tokio::time::sleep(self.jittered_delay(attempt)).await;
         }
     }
 }

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -108,15 +108,15 @@ impl S3LockConfig {
     }
 
     fn default_operation_timeout_secs() -> u64 {
-        30
+        15
     }
 
     fn default_operation_attempt_timeout_secs() -> u64 {
-        10
+        4
     }
 
     fn default_max_attempts() -> u32 {
-        3
+        2
     }
 }
 
@@ -181,6 +181,21 @@ impl S3LockBackend {
             return Err(Error::InvalidData(
                 "max_hold_secs must be >= ttl_secs".into(),
             ));
+        }
+        let heartbeat_interval = config.ttl_secs / 3;
+        let worst_case_attempt =
+            config.operation_attempt_timeout_secs * u64::from(config.max_attempts);
+        if worst_case_attempt >= heartbeat_interval {
+            warn!(
+                operation_attempt_timeout_secs = config.operation_attempt_timeout_secs,
+                max_attempts = config.max_attempts,
+                heartbeat_interval_secs = heartbeat_interval,
+                worst_case_secs = worst_case_attempt,
+                "Lock S3 client worst-case timeout ({worst_case_attempt}s) >= heartbeat interval \
+                 ({heartbeat_interval}s). A stuck S3 request could consume an entire heartbeat \
+                 tick, reducing the safety margin before TTL expiry. Consider reducing \
+                 operation_attempt_timeout_secs or max_attempts."
+            );
         }
         Ok(Self {
             store,
@@ -433,15 +448,29 @@ impl S3LockBackend {
                         let cached_etag = etag_cache.get(path).cloned();
                         let store = store.clone();
                         let instance_id = instance_id.clone();
+                        let tick_deadline = interval;
                         async move {
-                            let result = heartbeat_tick_path(
-                                &store,
-                                path,
-                                &instance_id,
-                                ttl_secs,
-                                cached_etag,
+                            // Cap each tick to the heartbeat interval. The slow path
+                            // (no cached ETag) issues two sequential SDK calls that
+                            // could each consume the full operation timeout, exceeding
+                            // the heartbeat interval and risking TTL expiry.
+                            let result = if let Ok(result) = tokio::time::timeout(
+                                tick_deadline,
+                                heartbeat_tick_path(
+                                    &store,
+                                    path,
+                                    &instance_id,
+                                    ttl_secs,
+                                    cached_etag,
+                                ),
                             )
-                            .await;
+                            .await
+                            {
+                                result
+                            } else {
+                                warn!(path, "Heartbeat tick timed out");
+                                HeartbeatPathResult::Failure
+                            };
                             (path.clone(), result)
                         }
                     }))

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -35,9 +35,9 @@ const MAX_LOCK_TTL_SECS: u64 = 3600;
 
 fn deserialize_ttl_secs<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
     let value = u64::deserialize(deserializer)?;
-    if value < 3 {
+    if value < 9 {
         return Err(serde::de::Error::custom(
-            "ttl_secs must be at least 3 (heartbeat runs at ttl/3)",
+            "ttl_secs must be at least 9 (heartbeat runs at ttl/3)",
         ));
     }
     Ok(value)
@@ -164,8 +164,8 @@ pub struct S3LockBackend {
 
 impl S3LockBackend {
     pub fn new(store: Arc<data_store::s3::Backend>, config: &S3LockConfig) -> Result<Self, Error> {
-        if config.ttl_secs < 3 {
-            return Err(Error::InvalidData("ttl_secs must be at least 3".into()));
+        if config.ttl_secs < 9 {
+            return Err(Error::InvalidData("ttl_secs must be at least 9".into()));
         }
         if config.retry_delay_ms < 1 {
             return Err(Error::InvalidData(

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -2,6 +2,7 @@
 mod tests;
 
 use std::{
+    collections::HashMap,
     io::ErrorKind,
     sync::{
         Arc,
@@ -198,18 +199,24 @@ impl S3LockBackend {
         Duration::from_millis(total_ms)
     }
 
-    fn make_payload(&self) -> Vec<u8> {
+    fn make_payload(&self) -> Result<Vec<u8>, Error> {
         let payload = S3LockPayload {
             instance_id: self.instance_id.clone(),
             refreshed_at: Utc::now(),
             ttl_secs: self.ttl_secs,
         };
-        serde_json::to_vec(&payload).expect("lock payload serialization cannot fail")
+        serde_json::to_vec(&payload)
+            .map_err(|e| Error::InvalidData(format!("lock payload serialization failed: {e}")))
     }
 
-    fn make_guard(&self, lock_paths: Vec<String>) -> LockGuard {
+    fn make_guard(
+        &self,
+        lock_paths: Vec<String>,
+        initial_etags: HashMap<String, String>,
+    ) -> LockGuard {
         let valid = Arc::new(AtomicBool::new(true));
-        let heartbeat_handle = self.spawn_heartbeat(lock_paths.clone(), valid.clone());
+        let heartbeat_handle =
+            self.spawn_heartbeat(lock_paths.clone(), valid.clone(), initial_etags);
         let store = self.store.clone();
         let instance_id = self.instance_id.clone();
         let valid_for_release = valid.clone();
@@ -278,15 +285,15 @@ impl S3LockBackend {
         )
     }
 
-    async fn try_acquire_key(&self, lock_path: &str) -> Result<bool, Error> {
-        let payload = self.make_payload();
+    async fn try_acquire_key(&self, lock_path: &str) -> Result<Option<String>, Error> {
+        let payload = self.make_payload()?;
         match self
             .store
             .put_object_if_not_exists(lock_path, payload)
             .await
         {
-            Ok(()) => Ok(true),
-            Err(data_store::Error::PreconditionFailed) => Ok(false),
+            Ok(etag) => Ok(etag),
+            Err(data_store::Error::PreconditionFailed) => Ok(None),
             Err(e) => Err(Error::StorageBackend(e.to_string())),
         }
     }
@@ -334,14 +341,22 @@ impl S3LockBackend {
             return RecoveryOutcome::Error("lock object missing ETag".to_string());
         };
 
+        let payload = match self.make_payload() {
+            Ok(p) => p,
+            Err(e) => {
+                LOCK_RECOVERIES.with_label_values(&["s3", "error"]).inc();
+                return RecoveryOutcome::Error(e.to_string());
+            }
+        };
+
         match self
             .store
-            .put_object_if_match(lock_path, &etag, self.make_payload())
+            .put_object_if_match(lock_path, &etag, payload)
             .await
         {
-            Ok(()) => {
+            Ok(new_etag) => {
                 LOCK_RECOVERIES.with_label_values(&["s3", "acquired"]).inc();
-                RecoveryOutcome::Acquired
+                RecoveryOutcome::Acquired(new_etag)
             }
             Err(data_store::Error::PreconditionFailed) => {
                 LOCK_RECOVERIES.with_label_values(&["s3", "failed"]).inc();
@@ -370,6 +385,7 @@ impl S3LockBackend {
         &self,
         paths: Vec<String>,
         valid: Arc<AtomicBool>,
+        initial_etags: HashMap<String, String>,
     ) -> tokio::task::JoinHandle<()> {
         let store = self.store.clone();
         let instance_id = self.instance_id.clone();
@@ -385,6 +401,7 @@ impl S3LockBackend {
             interval_timer.tick().await; // consume immediate first tick
 
             let mut consecutive_failures: u32 = 0;
+            let mut etag_cache: HashMap<String, String> = initial_etags;
 
             loop {
                 interval_timer.tick().await;
@@ -401,23 +418,42 @@ impl S3LockBackend {
                     return;
                 }
 
-                let results: Vec<HeartbeatPathResult> = join_all(
-                    paths
-                        .iter()
-                        .map(|path| heartbeat_tick_path(&store, path, &instance_id, ttl_secs)),
-                )
-                .await;
+                let results: Vec<(String, HeartbeatPathResult)> =
+                    join_all(paths.iter().map(|path| {
+                        let cached_etag = etag_cache.get(path).cloned();
+                        let store = store.clone();
+                        let instance_id = instance_id.clone();
+                        async move {
+                            let result = heartbeat_tick_path(
+                                &store,
+                                path,
+                                &instance_id,
+                                ttl_secs,
+                                cached_etag,
+                            )
+                            .await;
+                            (path.clone(), result)
+                        }
+                    }))
+                    .await;
 
                 let mut tick_had_failure = false;
-                for result in results {
+                for (path, result) in results {
                     match result {
-                        HeartbeatPathResult::Ok => {}
+                        HeartbeatPathResult::Ok(new_etag) => {
+                            if let Some(etag) = new_etag {
+                                etag_cache.insert(path, etag);
+                            } else {
+                                etag_cache.remove(&path);
+                            }
+                        }
                         HeartbeatPathResult::Invalidate(reason) => {
                             LOCK_INVALIDATIONS.with_label_values(&["s3", reason]).inc();
                             valid.store(false, Ordering::Release);
                             return;
                         }
                         HeartbeatPathResult::Failure => {
+                            etag_cache.remove(&path);
                             tick_had_failure = true;
                         }
                     }
@@ -445,7 +481,7 @@ impl S3LockBackend {
 }
 
 enum HeartbeatPathResult {
-    Ok,
+    Ok(Option<String>),
     Invalidate(&'static str),
     Failure,
 }
@@ -455,10 +491,47 @@ async fn heartbeat_tick_path(
     path: &str,
     instance_id: &str,
     ttl_secs: u64,
+    cached_etag: Option<String>,
 ) -> HeartbeatPathResult {
+    let make_payload_bytes = || -> Result<Vec<u8>, String> {
+        let payload = S3LockPayload {
+            instance_id: instance_id.to_owned(),
+            refreshed_at: Utc::now(),
+            ttl_secs,
+        };
+        serde_json::to_vec(&payload).map_err(|e| format!("lock payload serialization failed: {e}"))
+    };
+
+    if let Some(etag) = cached_etag {
+        let payload = match make_payload_bytes() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(path, error = %e, "Failed to serialize lock payload");
+                return HeartbeatPathResult::Failure;
+            }
+        };
+        match store.put_object_if_match(path, &etag, payload).await {
+            Ok(new_etag) => {
+                debug!(path, "Refreshed S3 lock heartbeat");
+                return HeartbeatPathResult::Ok(new_etag);
+            }
+            Err(data_store::Error::PreconditionFailed) => {
+                warn!(
+                    path,
+                    "Lock ETag changed, ownership lost, stopping heartbeat"
+                );
+                return HeartbeatPathResult::Invalidate("ownership_lost");
+            }
+            Err(e) => {
+                warn!(path, error = %e, "Failed to refresh S3 lock heartbeat");
+                return HeartbeatPathResult::Failure;
+            }
+        }
+    }
+
     let etag = match store.read_with_etag(path).await {
-        Ok((data, etag)) => {
-            if let Ok(existing) = serde_json::from_slice::<S3LockPayload>(&data)
+        Ok((body, etag)) => {
+            if let Ok(existing) = serde_json::from_slice::<S3LockPayload>(&body)
                 && existing.instance_id != instance_id
             {
                 warn!(
@@ -489,17 +562,18 @@ async fn heartbeat_tick_path(
         return HeartbeatPathResult::Invalidate("etag_unavailable");
     };
 
-    let payload = S3LockPayload {
-        instance_id: instance_id.to_owned(),
-        refreshed_at: Utc::now(),
-        ttl_secs,
+    let payload = match make_payload_bytes() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(path, error = %e, "Failed to serialize lock payload");
+            return HeartbeatPathResult::Failure;
+        }
     };
-    let data = serde_json::to_vec(&payload).expect("lock payload serialization cannot fail");
 
-    match store.put_object_if_match(path, &etag, data).await {
-        Ok(()) => {
+    match store.put_object_if_match(path, &etag, payload).await {
+        Ok(new_etag) => {
             debug!(path, "Refreshed S3 lock heartbeat");
-            HeartbeatPathResult::Ok
+            HeartbeatPathResult::Ok(new_etag)
         }
         Err(data_store::Error::PreconditionFailed) => {
             warn!(
@@ -517,7 +591,7 @@ async fn heartbeat_tick_path(
 
 #[cfg_attr(test, derive(Debug))]
 enum RecoveryOutcome {
-    Acquired,
+    Acquired(Option<String>),
     NotStale,
     Retry,
     Failed,
@@ -543,7 +617,7 @@ impl S3LockBackend {
 }
 
 enum AcquireRoundOutcome {
-    AllAcquired,
+    AllAcquired(HashMap<String, String>),
     HardError(Error),
     RecoveryError {
         msg: String,
@@ -571,16 +645,21 @@ impl S3LockBackend {
                 async move { (i, self.try_acquire_key(&path).await) }
             })
             .collect();
-        let results: Vec<(usize, Result<bool, Error>)> = join_all(futs).await;
+        let results: Vec<(usize, Result<Option<String>, Error>)> = join_all(futs).await;
 
+        let mut acquired_etags: HashMap<String, String> = HashMap::new();
         let mut acquired_paths = Vec::new();
         let mut failed_indices = Vec::new();
         let mut hard_error: Option<Error> = None;
 
         for (i, result) in &results {
             match result {
-                Ok(true) => acquired_paths.push(lock_paths[*i].clone()),
-                Ok(false) => failed_indices.push(*i),
+                Ok(Some(etag)) => {
+                    let path = lock_paths[*i].clone();
+                    acquired_etags.insert(path.clone(), etag.clone());
+                    acquired_paths.push(path);
+                }
+                Ok(None) => failed_indices.push(*i),
                 Err(e) => {
                     hard_error = Some(Error::StorageBackend(format!("S3 lock error: {e}")));
                     break;
@@ -594,7 +673,7 @@ impl S3LockBackend {
         }
 
         if failed_indices.is_empty() {
-            return AcquireRoundOutcome::AllAcquired;
+            return AcquireRoundOutcome::AllAcquired(acquired_etags);
         }
 
         let recovery_futs: Vec<_> = failed_indices
@@ -608,7 +687,13 @@ impl S3LockBackend {
         let mut recovered_paths = Vec::new();
         for (i, outcome) in join_all(recovery_futs).await {
             match outcome {
-                RecoveryOutcome::Acquired => recovered_paths.push(lock_paths[i].clone()),
+                RecoveryOutcome::Acquired(new_etag) => {
+                    let path = lock_paths[i].clone();
+                    if let Some(etag) = new_etag {
+                        acquired_etags.insert(path.clone(), etag);
+                    }
+                    recovered_paths.push(path);
+                }
                 RecoveryOutcome::Error(msg) => {
                     let mut to_release = acquired_paths;
                     to_release.extend(recovered_paths);
@@ -619,7 +704,7 @@ impl S3LockBackend {
         }
 
         if recovered_paths.len() + acquired_paths.len() == lock_paths.len() {
-            return AcquireRoundOutcome::AllAcquired;
+            return AcquireRoundOutcome::AllAcquired(acquired_etags);
         }
 
         AcquireRoundOutcome::Retry {
@@ -646,14 +731,14 @@ impl LockBackend for S3LockBackend {
 
         loop {
             match self.try_acquire_round(&lock_paths).await {
-                AcquireRoundOutcome::AllAcquired => {
+                AcquireRoundOutcome::AllAcquired(etags) => {
                     LOCK_ACQUISITION_DURATION
                         .with_label_values(&["s3"])
                         .observe(start.elapsed().as_secs_f64() * 1000.0);
                     LOCK_ACQUISITIONS
                         .with_label_values(&["s3", "success"])
                         .inc();
-                    return Ok(self.make_guard(lock_paths));
+                    return Ok(self.make_guard(lock_paths, etags));
                 }
                 AcquireRoundOutcome::HardError(e) => {
                     LOCK_ACQUISITION_DURATION

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -172,6 +172,11 @@ impl S3LockBackend {
                 "retry_delay_ms must be at least 1".into(),
             ));
         }
+        if config.ttl_secs > MAX_LOCK_TTL_SECS {
+            return Err(Error::InvalidData(format!(
+                "ttl_secs must be at most {MAX_LOCK_TTL_SECS}"
+            )));
+        }
         if config.max_hold_secs < config.ttl_secs {
             return Err(Error::InvalidData(
                 "max_hold_secs must be >= ttl_secs".into(),

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -220,6 +220,11 @@ impl S3LockBackend {
         let store = self.store.clone();
         let instance_id = self.instance_id.clone();
         let valid_for_release = valid.clone();
+        // Release performs a best-effort ownership check before deleting lock objects.
+        // S3 does not support conditional DELETE, so there is a narrow TOCTOU window
+        // between the ownership read and the delete where another instance could have
+        // recovered the lock. The worst case is a transient lock disappearance — the
+        // new owner's next heartbeat will re-create the lock object.
         LockGuard::with_async_release_and_heartbeat(
             move || {
                 Box::pin(async move {
@@ -712,6 +717,48 @@ impl S3LockBackend {
             recovered: recovered_paths,
         }
     }
+
+    async fn try_acquire_sequential(&self, lock_paths: &[String]) -> AcquireRoundOutcome {
+        let mut acquired_etags: HashMap<String, String> = HashMap::new();
+        let mut acquired_paths: Vec<String> = Vec::new();
+
+        for path in lock_paths {
+            match self.try_acquire_key(path).await {
+                Ok(Some(etag)) => {
+                    acquired_etags.insert(path.clone(), etag);
+                    acquired_paths.push(path.clone());
+                }
+                Ok(None) => match self.try_recover_stale_lock(path).await {
+                    RecoveryOutcome::Acquired(new_etag) => {
+                        if let Some(etag) = new_etag {
+                            acquired_etags.insert(path.clone(), etag);
+                        }
+                        acquired_paths.push(path.clone());
+                    }
+                    RecoveryOutcome::Error(msg) => {
+                        self.release_paths(&acquired_paths).await;
+                        return AcquireRoundOutcome::RecoveryError {
+                            msg,
+                            to_release: Vec::new(),
+                        };
+                    }
+                    _ => {
+                        self.release_paths(&acquired_paths).await;
+                        return AcquireRoundOutcome::Retry {
+                            acquired: Vec::new(),
+                            recovered: Vec::new(),
+                        };
+                    }
+                },
+                Err(e) => {
+                    self.release_paths(&acquired_paths).await;
+                    return AcquireRoundOutcome::HardError(e);
+                }
+            }
+        }
+
+        AcquireRoundOutcome::AllAcquired(acquired_etags)
+    }
 }
 
 #[async_trait]
@@ -728,9 +775,15 @@ impl LockBackend for S3LockBackend {
         lock_paths.dedup();
 
         let mut retries = self.max_retries;
+        let mut use_sequential = false;
 
         loop {
-            match self.try_acquire_round(&lock_paths).await {
+            let round_result = if use_sequential {
+                self.try_acquire_sequential(&lock_paths).await
+            } else {
+                self.try_acquire_round(&lock_paths).await
+            };
+            match round_result {
                 AcquireRoundOutcome::AllAcquired(etags) => {
                     LOCK_ACQUISITION_DURATION
                         .with_label_values(&["s3"])
@@ -779,6 +832,7 @@ impl LockBackend for S3LockBackend {
                     }
                     retries -= 1;
                     let attempt = self.max_retries - retries;
+                    use_sequential = true;
                     LOCK_RETRIES.with_label_values(&["s3"]).inc();
                     debug!(retries_left = retries, "S3 lock busy, retrying...");
                     tokio::time::sleep(self.jittered_delay(attempt)).await;

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -401,9 +401,16 @@ impl S3LockBackend {
                     return;
                 }
 
+                let results: Vec<HeartbeatPathResult> = join_all(
+                    paths
+                        .iter()
+                        .map(|path| heartbeat_tick_path(&store, path, &instance_id, ttl_secs)),
+                )
+                .await;
+
                 let mut tick_had_failure = false;
-                for path in &paths {
-                    match heartbeat_tick_path(&store, path, &instance_id, ttl_secs).await {
+                for result in results {
+                    match result {
                         HeartbeatPathResult::Ok => {}
                         HeartbeatPathResult::Invalidate(reason) => {
                             LOCK_INVALIDATIONS.with_label_values(&["s3", reason]).inc();

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -28,6 +28,7 @@ use crate::{
             Error,
             lock::{LockBackend, LockGuard},
         },
+        path_builder,
     },
 };
 
@@ -208,7 +209,8 @@ impl S3LockBackend {
     }
 
     fn lock_path(key: &str) -> String {
-        format!("_locks/{key}")
+        let shard = path_builder::shard_key(key);
+        format!("_locks/{shard}/{key}")
     }
 
     fn jittered_delay(&self, attempt: u32) -> Duration {

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -262,8 +262,7 @@ impl S3LockBackend {
                     let futs: Vec<_> = lock_paths
                         .iter()
                         .map(|path| {
-                            let cached_etag =
-                                etag_cache.read().unwrap().get(path).cloned();
+                            let cached_etag = etag_cache.read().unwrap().get(path).cloned();
                             release_lock_path(
                                 store.clone(),
                                 path.clone(),
@@ -613,7 +612,10 @@ async fn release_lock_path(
         match store.delete_if_match(&path, &etag).await {
             Ok(()) => {}
             Err(data_store::Error::PreconditionFailed) => {
-                debug!(path, "Lock ETag changed during release, another instance owns it");
+                debug!(
+                    path,
+                    "Lock ETag changed during release, another instance owns it"
+                );
             }
             Err(e) => warn!(path, error = %e, "Failed to delete lock on release"),
         }

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -5,7 +5,7 @@ use std::{
     collections::HashMap,
     io::ErrorKind,
     sync::{
-        Arc,
+        Arc, RwLock,
         atomic::{AtomicBool, Ordering},
     },
     time::Duration,
@@ -243,16 +243,13 @@ impl S3LockBackend {
         initial_etags: HashMap<String, String>,
     ) -> LockGuard {
         let valid = Arc::new(AtomicBool::new(true));
+        let etag_cache = Arc::new(RwLock::new(initial_etags));
         let heartbeat_handle =
-            self.spawn_heartbeat(lock_paths.clone(), valid.clone(), initial_etags);
+            self.spawn_heartbeat(lock_paths.clone(), valid.clone(), etag_cache.clone());
         let store = self.store.clone();
         let instance_id = self.instance_id.clone();
         let valid_for_release = valid.clone();
         let supports_conditional_delete = self.supports_conditional_delete;
-        // When conditional DELETE is available, lock release uses delete_if_match to
-        // atomically verify ownership via ETag. When not available, there is a narrow
-        // TOCTOU window between the ownership read and the delete — see
-        // ConditionalCapabilities.delete_if_match.
         LockGuard::with_async_release_and_heartbeat(
             move || {
                 Box::pin(async move {
@@ -260,89 +257,20 @@ impl S3LockBackend {
                         debug!("Lock ownership lost, skipping delete on release");
                         return;
                     }
+                    // Read cached ETags outside the futures so the RwLock guard is not
+                    // held across any await point.
                     let futs: Vec<_> = lock_paths
                         .iter()
                         .map(|path| {
-                            let store = store.clone();
-                            let path = path.clone();
-                            let instance_id = instance_id.clone();
-                            async move {
-                                match store.read_with_etag(&path).await {
-                                    Ok((data, etag)) => {
-                                        match serde_json::from_slice::<S3LockPayload>(&data) {
-                                            Ok(payload) if payload.instance_id == instance_id => {
-                                                if supports_conditional_delete {
-                                                    if let Some(etag) = etag {
-                                                        match store
-                                                            .delete_if_match(&path, &etag)
-                                                            .await
-                                                        {
-                                                            Ok(()) => {}
-                                                            Err(
-                                                                data_store::Error::PreconditionFailed,
-                                                            ) => {
-                                                                debug!(
-                                                                    path,
-                                                                    "Lock ETag changed during \
-                                                                     release, another instance \
-                                                                     owns it"
-                                                                );
-                                                            }
-                                                            Err(e) => {
-                                                                warn!(
-                                                                    path,
-                                                                    error = %e,
-                                                                    "Failed to delete lock on \
-                                                                     release"
-                                                                );
-                                                            }
-                                                        }
-                                                    } else if let Err(e) =
-                                                        store.delete(&path).await
-                                                    {
-                                                        warn!(
-                                                            path,
-                                                            error = %e,
-                                                            "Failed to delete lock on release"
-                                                        );
-                                                    }
-                                                } else if let Err(e) = store.delete(&path).await {
-                                                    warn!(
-                                                        path,
-                                                        error = %e,
-                                                        "Failed to delete lock on release"
-                                                    );
-                                                }
-                                            }
-                                            Ok(payload) => {
-                                                debug!(
-                                                    path,
-                                                    expected = instance_id,
-                                                    found = payload.instance_id,
-                                                    "Lock ownership changed, skipping delete"
-                                                );
-                                            }
-                                            Err(e) => {
-                                                warn!(
-                                                    path,
-                                                    error = %e,
-                                                    "Failed to deserialize lock payload on release, skipping delete"
-                                                );
-                                            }
-                                        }
-                                    }
-                                    Err(e) if e.kind() == ErrorKind::NotFound => {
-                                        debug!(path, "Lock already deleted");
-                                    }
-                                    Err(e) => {
-                                        warn!(
-                                            path,
-                                            error = %e,
-                                            "Failed to read lock for ownership check on release, skipping delete"
-                                        );
-                                    }
-                                }
-                            }
+                            let cached_etag =
+                                etag_cache.read().unwrap().get(path).cloned();
+                            release_lock_path(
+                                store.clone(),
+                                path.clone(),
+                                instance_id.clone(),
+                                cached_etag,
+                                supports_conditional_delete,
+                            )
                         })
                         .collect();
                     join_all(futs).await;
@@ -453,7 +381,7 @@ impl S3LockBackend {
         &self,
         paths: Vec<String>,
         valid: Arc<AtomicBool>,
-        initial_etags: HashMap<String, String>,
+        etag_cache: Arc<RwLock<HashMap<String, String>>>,
     ) -> tokio::task::JoinHandle<()> {
         let store = self.store.clone();
         let instance_id = self.instance_id.clone();
@@ -469,7 +397,6 @@ impl S3LockBackend {
             interval_timer.tick().await; // consume immediate first tick
 
             let mut consecutive_failures: u32 = 0;
-            let mut etag_cache: HashMap<String, String> = initial_etags;
 
             loop {
                 interval_timer.tick().await;
@@ -488,7 +415,7 @@ impl S3LockBackend {
 
                 let results: Vec<(String, HeartbeatPathResult)> =
                     join_all(paths.iter().map(|path| {
-                        let cached_etag = etag_cache.get(path).cloned();
+                        let cached_etag = etag_cache.read().unwrap().get(path).cloned();
                         let store = store.clone();
                         let instance_id = instance_id.clone();
                         let tick_deadline = interval;
@@ -523,10 +450,11 @@ impl S3LockBackend {
                 for (path, result) in results {
                     match result {
                         HeartbeatPathResult::Ok(new_etag) => {
+                            let mut cache = etag_cache.write().unwrap();
                             if let Some(etag) = new_etag {
-                                etag_cache.insert(path, etag);
+                                cache.insert(path, etag);
                             } else {
-                                etag_cache.remove(&path);
+                                cache.remove(&path);
                             }
                         }
                         HeartbeatPathResult::Invalidate(reason) => {
@@ -535,7 +463,7 @@ impl S3LockBackend {
                             return;
                         }
                         HeartbeatPathResult::Failure => {
-                            etag_cache.remove(&path);
+                            etag_cache.write().unwrap().remove(&path);
                             tick_had_failure = true;
                         }
                     }
@@ -667,6 +595,75 @@ async fn heartbeat_tick_path(
         Err(e) => {
             warn!(path, error = %e, "Failed to refresh S3 lock heartbeat");
             HeartbeatPathResult::Failure
+        }
+    }
+}
+
+async fn release_lock_path(
+    store: Arc<data_store::s3::Backend>,
+    path: String,
+    instance_id: String,
+    cached_etag: Option<String>,
+    supports_conditional_delete: bool,
+) {
+    // Fast path: use the heartbeat's cached ETag for an atomic conditional delete
+    // without a preceding GET. A stale ETag (i.e. another instance took over) returns
+    // PreconditionFailed and leaves the new owner's lock intact.
+    if supports_conditional_delete && let Some(etag) = cached_etag {
+        match store.delete_if_match(&path, &etag).await {
+            Ok(()) => {}
+            Err(data_store::Error::PreconditionFailed) => {
+                debug!(path, "Lock ETag changed during release, another instance owns it");
+            }
+            Err(e) => warn!(path, error = %e, "Failed to delete lock on release"),
+        }
+        return;
+    }
+    // Slow path: no cached ETag — verify ownership via GET then delete. Covers the
+    // case where no heartbeat tick has run yet and the non-conditional-delete fallback.
+    match store.read_with_etag(&path).await {
+        Ok((data, etag)) => match serde_json::from_slice::<S3LockPayload>(&data) {
+            Ok(payload) if payload.instance_id == instance_id => {
+                if supports_conditional_delete && let Some(etag) = etag {
+                    match store.delete_if_match(&path, &etag).await {
+                        Ok(()) => {}
+                        Err(data_store::Error::PreconditionFailed) => {
+                            debug!(
+                                path,
+                                "Lock ETag changed during release, another instance owns it"
+                            );
+                        }
+                        Err(e) => warn!(path, error = %e, "Failed to delete lock on release"),
+                    }
+                } else if let Err(e) = store.delete(&path).await {
+                    warn!(path, error = %e, "Failed to delete lock on release");
+                }
+            }
+            Ok(payload) => {
+                debug!(
+                    path,
+                    expected = instance_id,
+                    found = payload.instance_id,
+                    "Lock ownership changed, skipping delete"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    path,
+                    error = %e,
+                    "Failed to deserialize lock payload on release, skipping delete"
+                );
+            }
+        },
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            debug!(path, "Lock already deleted");
+        }
+        Err(e) => {
+            warn!(
+                path,
+                error = %e,
+                "Failed to read lock for ownership check on release, skipping delete"
+            );
         }
     }
 }

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -214,9 +214,9 @@ impl S3LockBackend {
     fn jittered_delay(&self, attempt: u32) -> Duration {
         let max_delay_ms: u64 = 1000;
         let base_ms = self.retry_delay_ms.saturating_mul(1u64 << attempt.min(6));
-        let jitter = simple_jitter(base_ms.min(max_delay_ms) / 2);
-        let total_ms = base_ms.saturating_add(jitter).min(max_delay_ms);
-        Duration::from_millis(total_ms)
+        let capped_ms = base_ms.min(max_delay_ms);
+        let jitter = simple_jitter(capped_ms / 2);
+        Duration::from_millis(capped_ms.saturating_add(jitter))
     }
 
     fn make_payload(&self) -> Result<Vec<u8>, Error> {
@@ -671,11 +671,11 @@ enum AcquireRoundOutcome {
 impl S3LockBackend {
     async fn try_acquire_round(&self, lock_paths: &[String]) -> AcquireRoundOutcome {
         // Parallel PUTs with overlapping key sets across instances can cause
-        // repeated rollbacks (practical livelock). Sorted key order prevents
-        // circular wait in sequential protocols but does not prevent collision
-        // in a parallel-issue protocol. The retry budget (`max_retries`) bounds
-        // total attempts. Randomized jitter (simple_jitter) desynchronises
-        // retrying instances to break collision patterns.
+        // repeated rollbacks. This parallel round is used only for the first
+        // attempt (optimistic fast path). On any failure, `acquire` switches
+        // to `try_acquire_sequential` which acquires keys one-by-one in sorted
+        // order, eliminating circular wait and preventing livelock. Randomized
+        // jitter on retry delays desynchronises retrying instances.
         let futs: Vec<_> = lock_paths
             .iter()
             .enumerate()

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -161,10 +161,15 @@ pub struct S3LockBackend {
     max_hold_secs: u64,
     max_retries: u32,
     retry_delay_ms: u64,
+    supports_conditional_delete: bool,
 }
 
 impl S3LockBackend {
-    pub fn new(store: Arc<data_store::s3::Backend>, config: &S3LockConfig) -> Result<Self, Error> {
+    pub fn new(
+        store: Arc<data_store::s3::Backend>,
+        config: &S3LockConfig,
+        supports_conditional_delete: bool,
+    ) -> Result<Self, Error> {
         if config.ttl_secs < 9 {
             return Err(Error::InvalidData("ttl_secs must be at least 9".into()));
         }
@@ -205,6 +210,7 @@ impl S3LockBackend {
             max_hold_secs: config.max_hold_secs,
             max_retries: config.max_retries,
             retry_delay_ms: config.retry_delay_ms,
+            supports_conditional_delete,
         })
     }
 
@@ -242,11 +248,11 @@ impl S3LockBackend {
         let store = self.store.clone();
         let instance_id = self.instance_id.clone();
         let valid_for_release = valid.clone();
-        // Release performs a best-effort ownership check before deleting lock objects.
-        // S3 does not support conditional DELETE, so there is a narrow TOCTOU window
-        // between the ownership read and the delete where another instance could have
-        // recovered the lock. The worst case is a transient lock disappearance — the
-        // new owner's next heartbeat will re-create the lock object.
+        let supports_conditional_delete = self.supports_conditional_delete;
+        // When conditional DELETE is available, lock release uses delete_if_match to
+        // atomically verify ownership via ETag. When not available, there is a narrow
+        // TOCTOU window between the ownership read and the delete — see
+        // ConditionalCapabilities.delete_if_match.
         LockGuard::with_async_release_and_heartbeat(
             move || {
                 Box::pin(async move {
@@ -262,10 +268,45 @@ impl S3LockBackend {
                             let instance_id = instance_id.clone();
                             async move {
                                 match store.read_with_etag(&path).await {
-                                    Ok((data, _)) => {
+                                    Ok((data, etag)) => {
                                         match serde_json::from_slice::<S3LockPayload>(&data) {
                                             Ok(payload) if payload.instance_id == instance_id => {
-                                                if let Err(e) = store.delete(&path).await {
+                                                if supports_conditional_delete {
+                                                    if let Some(etag) = etag {
+                                                        match store
+                                                            .delete_if_match(&path, &etag)
+                                                            .await
+                                                        {
+                                                            Ok(()) => {}
+                                                            Err(
+                                                                data_store::Error::PreconditionFailed,
+                                                            ) => {
+                                                                debug!(
+                                                                    path,
+                                                                    "Lock ETag changed during \
+                                                                     release, another instance \
+                                                                     owns it"
+                                                                );
+                                                            }
+                                                            Err(e) => {
+                                                                warn!(
+                                                                    path,
+                                                                    error = %e,
+                                                                    "Failed to delete lock on \
+                                                                     release"
+                                                                );
+                                                            }
+                                                        }
+                                                    } else if let Err(e) =
+                                                        store.delete(&path).await
+                                                    {
+                                                        warn!(
+                                                            path,
+                                                            error = %e,
+                                                            "Failed to delete lock on release"
+                                                        );
+                                                    }
+                                                } else if let Err(e) = store.delete(&path).await {
                                                     warn!(
                                                         path,
                                                         error = %e,

--- a/src/registry/metadata_store/lock/s3/mod.rs
+++ b/src/registry/metadata_store/lock/s3/mod.rs
@@ -75,6 +75,12 @@ pub struct S3LockConfig {
         deserialize_with = "deserialize_max_hold_secs"
     )]
     pub max_hold_secs: u64,
+    #[serde(default = "S3LockConfig::default_operation_timeout_secs")]
+    pub operation_timeout_secs: u64,
+    #[serde(default = "S3LockConfig::default_operation_attempt_timeout_secs")]
+    pub operation_attempt_timeout_secs: u64,
+    #[serde(default = "S3LockConfig::default_max_attempts")]
+    pub max_attempts: u32,
 }
 
 impl S3LockConfig {
@@ -93,6 +99,18 @@ impl S3LockConfig {
     fn default_max_hold_secs() -> u64 {
         300
     }
+
+    fn default_operation_timeout_secs() -> u64 {
+        30
+    }
+
+    fn default_operation_attempt_timeout_secs() -> u64 {
+        10
+    }
+
+    fn default_max_attempts() -> u32 {
+        3
+    }
 }
 
 impl Default for S3LockConfig {
@@ -102,6 +120,9 @@ impl Default for S3LockConfig {
             max_retries: Self::default_max_retries(),
             retry_delay_ms: Self::default_retry_delay_ms(),
             max_hold_secs: Self::default_max_hold_secs(),
+            operation_timeout_secs: Self::default_operation_timeout_secs(),
+            operation_attempt_timeout_secs: Self::default_operation_attempt_timeout_secs(),
+            max_attempts: Self::default_max_attempts(),
         }
     }
 }

--- a/src/registry/metadata_store/lock/s3/tests.rs
+++ b/src/registry/metadata_store/lock/s3/tests.rs
@@ -1,4 +1,10 @@
-use std::{io::ErrorKind, sync::Arc};
+use std::{
+    io::ErrorKind,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use chrono::Utc;
 
@@ -367,4 +373,142 @@ async fn test_release_skips_delete_when_ownership_lost() {
     );
 
     let _ = store.delete("_locks/owned_key").await;
+}
+
+/// Spawns N tasks that race for the same lock key with retries enabled.
+/// Verifies mutual exclusion (at most 1 holder at any time) and that all
+/// tasks eventually succeed (no starvation from retry exhaustion).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent_contention_single_key() {
+    let store = test_store("s3lock_contention_");
+    let num_tasks: usize = 5;
+    let iterations_per_task: usize = 3;
+    let concurrent_holders = Arc::new(AtomicUsize::new(0));
+    let max_observed = Arc::new(AtomicUsize::new(0));
+
+    let mut handles = Vec::new();
+    for task_id in 0..num_tasks {
+        let store = store.clone();
+        let concurrent_holders = concurrent_holders.clone();
+        let max_observed = max_observed.clone();
+        handles.push(tokio::spawn(async move {
+            let backend = S3LockBackend::new(
+                store,
+                &S3LockConfig {
+                    ttl_secs: 9,
+                    max_retries: 50,
+                    retry_delay_ms: 10,
+                    max_hold_secs: 300,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+            for iter in 0..iterations_per_task {
+                let guard = backend
+                    .acquire(&["contended_key".to_string()])
+                    .await
+                    .unwrap_or_else(|e| {
+                        panic!("Task {task_id} iter {iter} failed to acquire: {e}")
+                    });
+
+                let prev = concurrent_holders.fetch_add(1, Ordering::SeqCst);
+                max_observed.fetch_max(prev + 1, Ordering::SeqCst);
+                assert_eq!(
+                    prev,
+                    0,
+                    "Task {task_id} iter {iter}: mutual exclusion violated ({} concurrent holders)",
+                    prev + 1
+                );
+
+                // Simulate brief work under lock
+                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+                concurrent_holders.fetch_sub(1, Ordering::SeqCst);
+                guard.release().await;
+            }
+        }));
+    }
+
+    let results = futures_util::future::join_all(handles).await;
+    for (i, result) in results.into_iter().enumerate() {
+        result.unwrap_or_else(|e| panic!("Task {i} panicked: {e}"));
+    }
+
+    assert_eq!(
+        max_observed.load(Ordering::SeqCst),
+        1,
+        "At most 1 task should hold the lock at any time"
+    );
+}
+
+/// Three tasks acquire overlapping multi-key lock sets, exercising the
+/// parallel-to-sequential fallback that prevents livelock. Key sets:
+///   Task A: [k1, k2]
+///   Task B: [k2, k3]
+///   Task C: [k1, k3]
+/// Each pair shares exactly one key, maximising contention. All tasks
+/// must eventually succeed — starvation would indicate a livelock.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent_contention_overlapping_keys() {
+    let store = test_store("s3lock_overlap_");
+    let concurrent_holders = Arc::new(AtomicUsize::new(0));
+    let max_observed = Arc::new(AtomicUsize::new(0));
+
+    let key_sets: Vec<Vec<String>> = vec![
+        vec!["k1".to_string(), "k2".to_string()],
+        vec!["k2".to_string(), "k3".to_string()],
+        vec!["k1".to_string(), "k3".to_string()],
+    ];
+
+    let mut handles = Vec::new();
+    for (task_id, keys) in key_sets.into_iter().enumerate() {
+        let store = store.clone();
+        let concurrent_holders = concurrent_holders.clone();
+        let max_observed = max_observed.clone();
+        handles.push(tokio::spawn(async move {
+            let backend = S3LockBackend::new(
+                store,
+                &S3LockConfig {
+                    ttl_secs: 9,
+                    max_retries: 50,
+                    retry_delay_ms: 10,
+                    max_hold_secs: 300,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+            for iter in 0..2 {
+                let guard = backend.acquire(&keys).await.unwrap_or_else(|e| {
+                    panic!("Task {task_id} iter {iter} failed to acquire: {e}")
+                });
+
+                let prev = concurrent_holders.fetch_add(1, Ordering::SeqCst);
+                max_observed.fetch_max(prev + 1, Ordering::SeqCst);
+                assert_eq!(
+                    prev,
+                    0,
+                    "Task {task_id} iter {iter}: mutual exclusion violated ({} concurrent holders)",
+                    prev + 1
+                );
+
+                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+                concurrent_holders.fetch_sub(1, Ordering::SeqCst);
+                guard.release().await;
+            }
+        }));
+    }
+
+    let results = futures_util::future::join_all(handles).await;
+    for (i, result) in results.into_iter().enumerate() {
+        result.unwrap_or_else(|e| panic!("Task {i} panicked: {e}"));
+    }
+
+    assert_eq!(
+        max_observed.load(Ordering::SeqCst),
+        1,
+        "At most 1 task should hold the lock at any time"
+    );
 }

--- a/src/registry/metadata_store/lock/s3/tests.rs
+++ b/src/registry/metadata_store/lock/s3/tests.rs
@@ -562,11 +562,16 @@ async fn test_lock_release_with_conditional_delete() {
 /// Verifies that when another instance takes over a lock key before the original holder
 /// releases, the release does not delete the new owner's lock object.
 ///
-/// This models the TOCTOU race that `supports_conditional_delete` is designed to guard
-/// against: instance A holds the lock, instance B force-writes a new lock payload
-/// (simulating lock recovery), and then A attempts to release. Because A's release logic
-/// reads the current payload and finds a foreign `instance_id`, it skips the delete and
-/// leaves B's object intact.
+/// Instance A holds the lock. Instance B force-writes a new lock payload (simulating lock
+/// recovery). A then releases. Because `supports_conditional_delete` is false, A falls
+/// back to the slow path: it GETs the current payload, finds B's `instance_id`, and skips
+/// the delete. B's object is left intact.
+///
+/// The complementary fast path (when `supports_conditional_delete` is true on a backend
+/// that properly enforces it) is guaranteed by the `delete_if_match` `ETag` check:
+/// A's cached `ETag` is stale after B's write, so the conditional delete returns
+/// `PreconditionFailed` and B's lock is preserved. `MinIO` does not enforce
+/// `If-Match` on `DeleteObject`, so that path cannot be tested here.
 #[tokio::test]
 async fn test_lock_release_conditional_delete_preserves_recovered_lock() {
     let store = test_store("s3lock_cond_preserve_");
@@ -579,7 +584,7 @@ async fn test_lock_release_conditional_delete_preserves_recovered_lock() {
             max_hold_secs: 300,
             ..Default::default()
         },
-        true,
+        false,
     )
     .unwrap();
 

--- a/src/registry/metadata_store/lock/s3/tests.rs
+++ b/src/registry/metadata_store/lock/s3/tests.rs
@@ -1,0 +1,363 @@
+use std::{io::ErrorKind, sync::Arc};
+
+use chrono::Utc;
+
+use super::{RecoveryOutcome, S3LockBackend, S3LockConfig, S3LockPayload};
+use crate::registry::{data_store, metadata_store::lock::LockBackend};
+
+fn test_store(prefix: &str) -> Arc<data_store::s3::Backend> {
+    let config = data_store::s3::BackendConfig {
+        access_key_id: "root".to_string(),
+        secret_key: "roottoor".to_string(),
+        endpoint: "http://127.0.0.1:9000".to_string(),
+        bucket: "registry".to_string(),
+        region: "us-east-1".to_string(),
+        key_prefix: prefix.to_string(),
+        ..Default::default()
+    };
+    Arc::new(data_store::s3::Backend::new(&config).unwrap())
+}
+
+fn test_backend(store: Arc<data_store::s3::Backend>) -> S3LockBackend {
+    S3LockBackend::new(
+        store,
+        &S3LockConfig {
+            ttl_secs: 30,
+            max_retries: 0,
+            retry_delay_ms: 5,
+            max_hold_secs: 300,
+        },
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_acquire_empty_keys() {
+    let store = test_store("s3lock_empty_");
+    let backend = test_backend(store);
+    let guard = backend.acquire(&[]).await;
+    assert!(guard.is_ok(), "Acquiring empty keys should succeed");
+    drop(guard);
+}
+
+#[tokio::test]
+async fn test_acquire_and_release() {
+    let store = test_store("s3lock_acq_rel_");
+    let backend1 = test_backend(store.clone());
+    let backend2 = test_backend(store);
+
+    let guard = backend1
+        .acquire(&["test_key".to_string()])
+        .await
+        .expect("Failed to acquire lock");
+
+    let attempt = backend2.acquire(&["test_key".to_string()]).await;
+    assert!(attempt.is_err(), "Should not acquire an already held lock");
+
+    guard.release().await;
+
+    let new_guard = backend1
+        .acquire(&["test_key".to_string()])
+        .await
+        .expect("Should acquire lock after release");
+    drop(new_guard);
+}
+
+#[tokio::test]
+async fn test_acquire_multiple_locks() {
+    let store = test_store("s3lock_multi_");
+    let backend1 = test_backend(store.clone());
+    let backend2 = test_backend(store);
+
+    let guard = backend1
+        .acquire(&["key1".to_string(), "key2".to_string()])
+        .await
+        .expect("Failed to acquire locks");
+
+    let attempt = backend2.acquire(&["key2".to_string()]).await;
+    assert!(
+        attempt.is_err(),
+        "Should not acquire a key from a held lock set"
+    );
+
+    guard.release().await;
+
+    let new_guard = backend2
+        .acquire(&["key1".to_string(), "key2".to_string()])
+        .await
+        .expect("Should acquire after release");
+    drop(new_guard);
+}
+
+#[tokio::test]
+async fn test_rollback_on_partial_acquire() {
+    let store = test_store("s3lock_rollback_");
+    let backend1 = test_backend(store.clone());
+    let backend2 = test_backend(store.clone());
+    let backend3 = test_backend(store);
+
+    let guard_a = backend1
+        .acquire(&["keyA".to_string()])
+        .await
+        .expect("Failed to acquire keyA");
+
+    let attempt = backend2
+        .acquire(&["keyA".to_string(), "keyB".to_string()])
+        .await;
+    assert!(attempt.is_err(), "Should fail since keyA is held");
+
+    // keyB should be available after rollback
+    let guard_b = backend3
+        .acquire(&["keyB".to_string()])
+        .await
+        .expect("keyB should be available after rollback");
+
+    drop(guard_a);
+    drop(guard_b);
+}
+
+#[tokio::test]
+async fn test_stale_lock_recovery() {
+    let store = test_store("s3lock_stale_");
+
+    // Write a lock and wait for it to expire (short TTL)
+    let stale_payload = S3LockPayload {
+        instance_id: "dead-instance".to_string(),
+        refreshed_at: Utc::now(),
+        ttl_secs: 3,
+    };
+    let data = serde_json::to_vec(&stale_payload).unwrap();
+    store
+        .put_object("_locks/stale_key", data)
+        .await
+        .expect("Failed to write stale lock");
+
+    // Wait for the lock to become stale (S3 LastModified-based expiry)
+    tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
+
+    let backend = S3LockBackend::new(
+        store,
+        &S3LockConfig {
+            ttl_secs: 3,
+            max_retries: 0,
+            retry_delay_ms: 1,
+            max_hold_secs: 300,
+        },
+    )
+    .unwrap();
+    let guard = backend
+        .acquire(&["stale_key".to_string()])
+        .await
+        .expect("Should recover stale lock and acquire");
+    drop(guard);
+}
+
+#[tokio::test]
+async fn test_non_stale_lock_not_recovered() {
+    let store = test_store("s3lock_nonstale_");
+    let backend = test_backend(store.clone());
+
+    let fresh_payload = S3LockPayload {
+        instance_id: "live-instance".to_string(),
+        refreshed_at: Utc::now(),
+        ttl_secs: 300,
+    };
+    let data = serde_json::to_vec(&fresh_payload).unwrap();
+    store
+        .put_object("_locks/fresh_key", data)
+        .await
+        .expect("Failed to write fresh lock");
+
+    let attempt = backend.acquire(&["fresh_key".to_string()]).await;
+    assert!(attempt.is_err(), "Should not recover a non-stale lock");
+
+    let _ = store.delete("_locks/fresh_key").await;
+}
+
+#[test]
+fn test_jitter_bounds() {
+    for max_ms in [1, 10, 100, 500, 1000] {
+        for _ in 0..20 {
+            let val = super::simple_jitter(max_ms);
+            assert!(val < max_ms, "jitter {val} should be < {max_ms}");
+        }
+    }
+}
+
+#[test]
+fn test_jitter_zero_guard() {
+    assert_eq!(super::simple_jitter(0), 0);
+}
+
+#[test]
+fn test_jitter_non_constant() {
+    let values: std::collections::HashSet<u64> =
+        (0..10).map(|_| super::simple_jitter(100)).collect();
+    assert!(
+        values.len() >= 2,
+        "Expected at least 2 distinct values in 10 calls, got {values:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_heartbeat_refreshes_lock() {
+    let store = test_store("s3lock_m6_hb_refresh_");
+    let backend = S3LockBackend::new(
+        store.clone(),
+        &S3LockConfig {
+            ttl_secs: 9,
+            max_retries: 0,
+            retry_delay_ms: 1,
+            max_hold_secs: 300,
+        },
+    )
+    .unwrap();
+
+    let guard = backend
+        .acquire(&["hb_test".to_string()])
+        .await
+        .expect("Failed to acquire lock");
+
+    // Wait longer than heartbeat interval (9/3 = 3s) so heartbeat fires at least once
+    tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
+
+    // Lock file should still exist (heartbeat refreshed it)
+    let data = store
+        .read("_locks/hb_test")
+        .await
+        .expect("Lock file should still exist after heartbeat refresh");
+    assert!(!data.is_empty(), "Lock payload should not be empty");
+
+    assert!(
+        guard.is_valid(),
+        "Guard should still be valid after heartbeat"
+    );
+    guard.release().await;
+}
+
+#[tokio::test]
+async fn test_heartbeat_invalidates_guard_on_ownership_loss() {
+    let store = test_store("s3lock_h1_hb_invalid_");
+    let backend = S3LockBackend::new(
+        store.clone(),
+        &S3LockConfig {
+            ttl_secs: 3,
+            max_retries: 0,
+            retry_delay_ms: 1,
+            max_hold_secs: 300,
+        },
+    )
+    .unwrap();
+
+    let guard = backend
+        .acquire(&["test_key".to_string()])
+        .await
+        .expect("Failed to acquire lock");
+
+    assert!(
+        guard.is_valid(),
+        "Guard should be valid immediately after acquire"
+    );
+
+    let stolen_payload = S3LockPayload {
+        instance_id: "thief-instance".to_string(),
+        refreshed_at: Utc::now(),
+        ttl_secs: 30,
+    };
+    let data = serde_json::to_vec(&stolen_payload).unwrap();
+    store
+        .put_object("_locks/test_key", data)
+        .await
+        .expect("Failed to overwrite lock");
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    assert!(
+        !guard.is_valid(),
+        "Guard should be invalid after heartbeat detects ownership loss"
+    );
+
+    guard.release().await;
+}
+
+#[tokio::test]
+async fn test_explicit_release_deletes_lock() {
+    let store = test_store("s3lock_h3_release_");
+    let backend = test_backend(store.clone());
+
+    let guard = backend
+        .acquire(&["test_key".to_string()])
+        .await
+        .expect("Failed to acquire lock");
+
+    guard.release().await;
+
+    let result = store.read("_locks/test_key").await;
+    assert_eq!(
+        result.unwrap_err().kind(),
+        ErrorKind::NotFound,
+        "Lock object should be deleted after explicit release"
+    );
+}
+
+#[tokio::test]
+async fn test_recovery_returns_retry_on_missing_lock() {
+    let store = test_store("s3lock_retry_vanished_");
+    let backend = test_backend(store);
+    let outcome = backend.test_try_recover("nonexistent_key").await;
+    assert!(
+        matches!(outcome, RecoveryOutcome::Retry),
+        "Expected Retry for vanished lock, got {outcome:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_release_skips_delete_when_ownership_lost() {
+    let store = test_store("s3lock_skip_del_");
+    let backend = S3LockBackend::new(
+        store.clone(),
+        &S3LockConfig {
+            ttl_secs: 3,
+            max_retries: 0,
+            retry_delay_ms: 1,
+            max_hold_secs: 300,
+        },
+    )
+    .unwrap();
+
+    let guard = backend
+        .acquire(&["owned_key".to_string()])
+        .await
+        .expect("Failed to acquire lock");
+
+    let stolen_payload = S3LockPayload {
+        instance_id: "thief-instance".to_string(),
+        refreshed_at: Utc::now(),
+        ttl_secs: 30,
+    };
+    let data = serde_json::to_vec(&stolen_payload).unwrap();
+    store
+        .put_object("_locks/owned_key", data)
+        .await
+        .expect("Failed to overwrite lock");
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    assert!(
+        !guard.is_valid(),
+        "Guard should be invalid after ownership loss"
+    );
+
+    guard.release().await;
+
+    let data = store
+        .read("_locks/owned_key")
+        .await
+        .expect("Thief's lock should still exist after release");
+    let payload: S3LockPayload = serde_json::from_slice(&data).unwrap();
+    assert_eq!(
+        payload.instance_id, "thief-instance",
+        "Thief's lock should not have been deleted"
+    );
+
+    let _ = store.delete("_locks/owned_key").await;
+}

--- a/src/registry/metadata_store/lock/s3/tests.rs
+++ b/src/registry/metadata_store/lock/s3/tests.rs
@@ -135,7 +135,7 @@ async fn test_stale_lock_recovery() {
     };
     let data = serde_json::to_vec(&stale_payload).unwrap();
     store
-        .put_object("_locks/stale_key", data)
+        .put_object(&S3LockBackend::lock_path("stale_key"), data)
         .await
         .expect("Failed to write stale lock");
 
@@ -172,14 +172,14 @@ async fn test_non_stale_lock_not_recovered() {
     };
     let data = serde_json::to_vec(&fresh_payload).unwrap();
     store
-        .put_object("_locks/fresh_key", data)
+        .put_object(&S3LockBackend::lock_path("fresh_key"), data)
         .await
         .expect("Failed to write fresh lock");
 
     let attempt = backend.acquire(&["fresh_key".to_string()]).await;
     assert!(attempt.is_err(), "Should not recover a non-stale lock");
 
-    let _ = store.delete("_locks/fresh_key").await;
+    let _ = store.delete(&S3LockBackend::lock_path("fresh_key")).await;
 }
 
 #[test]
@@ -232,7 +232,7 @@ async fn test_heartbeat_refreshes_lock() {
 
     // Lock file should still exist (heartbeat refreshed it)
     let data = store
-        .read("_locks/hb_test")
+        .read(&S3LockBackend::lock_path("hb_test"))
         .await
         .expect("Lock file should still exist after heartbeat refresh");
     assert!(!data.is_empty(), "Lock payload should not be empty");
@@ -276,7 +276,7 @@ async fn test_heartbeat_invalidates_guard_on_ownership_loss() {
     };
     let data = serde_json::to_vec(&stolen_payload).unwrap();
     store
-        .put_object("_locks/test_key", data)
+        .put_object(&S3LockBackend::lock_path("test_key"), data)
         .await
         .expect("Failed to overwrite lock");
 
@@ -303,7 +303,7 @@ async fn test_explicit_release_deletes_lock() {
 
     guard.release().await;
 
-    let result = store.read("_locks/test_key").await;
+    let result = store.read(&S3LockBackend::lock_path("test_key")).await;
     assert_eq!(
         result.unwrap_err().kind(),
         ErrorKind::NotFound,
@@ -349,7 +349,7 @@ async fn test_release_skips_delete_when_ownership_lost() {
     };
     let data = serde_json::to_vec(&stolen_payload).unwrap();
     store
-        .put_object("_locks/owned_key", data)
+        .put_object(&S3LockBackend::lock_path("owned_key"), data)
         .await
         .expect("Failed to overwrite lock");
 
@@ -363,7 +363,7 @@ async fn test_release_skips_delete_when_ownership_lost() {
     guard.release().await;
 
     let data = store
-        .read("_locks/owned_key")
+        .read(&S3LockBackend::lock_path("owned_key"))
         .await
         .expect("Thief's lock should still exist after release");
     let payload: S3LockPayload = serde_json::from_slice(&data).unwrap();
@@ -372,7 +372,7 @@ async fn test_release_skips_delete_when_ownership_lost() {
         "Thief's lock should not have been deleted"
     );
 
-    let _ = store.delete("_locks/owned_key").await;
+    let _ = store.delete(&S3LockBackend::lock_path("owned_key")).await;
 }
 
 /// Spawns N tasks that race for the same lock key with retries enabled.
@@ -510,5 +510,38 @@ async fn test_concurrent_contention_overlapping_keys() {
         max_observed.load(Ordering::SeqCst),
         1,
         "At most 1 task should hold the lock at any time"
+    );
+}
+
+#[test]
+fn test_lock_path_shards_across_prefixes() {
+    let path = S3LockBackend::lock_path("my_key");
+    assert!(path.starts_with("_locks/"));
+    assert!(path.ends_with("/my_key"));
+
+    // Shard is a 2-char hex prefix between _locks/ and /key
+    let parts: Vec<&str> = path.splitn(3, '/').collect();
+    assert_eq!(parts.len(), 3);
+    assert_eq!(parts[0], "_locks");
+    assert_eq!(parts[1].len(), 2);
+    assert!(parts[1].chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(parts[2], "my_key");
+
+    // Same key always maps to same shard
+    assert_eq!(
+        S3LockBackend::lock_path("my_key"),
+        S3LockBackend::lock_path("my_key")
+    );
+
+    // Different keys can map to different shards
+    let paths: std::collections::HashSet<String> = (0..100)
+        .map(|i| {
+            let p = S3LockBackend::lock_path(&format!("key_{i}"));
+            p.split('/').nth(1).unwrap().to_string()
+        })
+        .collect();
+    assert!(
+        paths.len() > 1,
+        "Expected multiple shard prefixes across 100 keys, got {paths:?}"
     );
 }

--- a/src/registry/metadata_store/lock/s3/tests.rs
+++ b/src/registry/metadata_store/lock/s3/tests.rs
@@ -7,18 +7,20 @@ use std::{
 };
 
 use chrono::Utc;
+use uuid::Uuid;
 
 use super::{RecoveryOutcome, S3LockBackend, S3LockConfig, S3LockPayload};
 use crate::registry::{data_store, metadata_store::lock::LockBackend};
 
 fn test_store(prefix: &str) -> Arc<data_store::s3::Backend> {
+    let run_id = Uuid::new_v4();
     let config = data_store::s3::BackendConfig {
         access_key_id: "root".to_string(),
         secret_key: "roottoor".to_string(),
         endpoint: "http://127.0.0.1:9000".to_string(),
         bucket: "registry".to_string(),
         region: "us-east-1".to_string(),
-        key_prefix: prefix.to_string(),
+        key_prefix: format!("{prefix}{run_id}_"),
         ..Default::default()
     };
     Arc::new(data_store::s3::Backend::new(&config).unwrap())

--- a/src/registry/metadata_store/lock/s3/tests.rs
+++ b/src/registry/metadata_store/lock/s3/tests.rs
@@ -139,7 +139,7 @@ async fn test_stale_lock_recovery() {
     let backend = S3LockBackend::new(
         store,
         &S3LockConfig {
-            ttl_secs: 3,
+            ttl_secs: 9,
             max_retries: 0,
             retry_delay_ms: 1,
             max_hold_secs: 300,
@@ -244,7 +244,7 @@ async fn test_heartbeat_invalidates_guard_on_ownership_loss() {
     let backend = S3LockBackend::new(
         store.clone(),
         &S3LockConfig {
-            ttl_secs: 3,
+            ttl_secs: 9,
             max_retries: 0,
             retry_delay_ms: 1,
             max_hold_secs: 300,
@@ -274,7 +274,8 @@ async fn test_heartbeat_invalidates_guard_on_ownership_loss() {
         .await
         .expect("Failed to overwrite lock");
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    // Heartbeat interval is ttl/3 = 3s; sleep 4s to ensure at least one tick fires
+    tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
 
     assert!(
         !guard.is_valid(),
@@ -321,7 +322,7 @@ async fn test_release_skips_delete_when_ownership_lost() {
     let backend = S3LockBackend::new(
         store.clone(),
         &S3LockConfig {
-            ttl_secs: 3,
+            ttl_secs: 9,
             max_retries: 0,
             retry_delay_ms: 1,
             max_hold_secs: 300,
@@ -346,7 +347,8 @@ async fn test_release_skips_delete_when_ownership_lost() {
         .await
         .expect("Failed to overwrite lock");
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    // Heartbeat interval is ttl/3 = 3s; sleep 4s to ensure at least one tick fires
+    tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
     assert!(
         !guard.is_valid(),
         "Guard should be invalid after ownership loss"

--- a/src/registry/metadata_store/lock/s3/tests.rs
+++ b/src/registry/metadata_store/lock/s3/tests.rs
@@ -26,6 +26,7 @@ fn test_backend(store: Arc<data_store::s3::Backend>) -> S3LockBackend {
             max_retries: 0,
             retry_delay_ms: 5,
             max_hold_secs: 300,
+            ..Default::default()
         },
     )
     .unwrap()
@@ -142,6 +143,7 @@ async fn test_stale_lock_recovery() {
             max_retries: 0,
             retry_delay_ms: 1,
             max_hold_secs: 300,
+            ..Default::default()
         },
     )
     .unwrap();
@@ -209,6 +211,7 @@ async fn test_heartbeat_refreshes_lock() {
             max_retries: 0,
             retry_delay_ms: 1,
             max_hold_secs: 300,
+            ..Default::default()
         },
     )
     .unwrap();
@@ -245,6 +248,7 @@ async fn test_heartbeat_invalidates_guard_on_ownership_loss() {
             max_retries: 0,
             retry_delay_ms: 1,
             max_hold_secs: 300,
+            ..Default::default()
         },
     )
     .unwrap();
@@ -321,6 +325,7 @@ async fn test_release_skips_delete_when_ownership_lost() {
             max_retries: 0,
             retry_delay_ms: 1,
             max_hold_secs: 300,
+            ..Default::default()
         },
     )
     .unwrap();

--- a/src/registry/metadata_store/lock/s3/tests.rs
+++ b/src/registry/metadata_store/lock/s3/tests.rs
@@ -36,6 +36,7 @@ fn test_backend(store: Arc<data_store::s3::Backend>) -> S3LockBackend {
             max_hold_secs: 300,
             ..Default::default()
         },
+        false,
     )
     .unwrap()
 }
@@ -153,6 +154,7 @@ async fn test_stale_lock_recovery() {
             max_hold_secs: 300,
             ..Default::default()
         },
+        false,
     )
     .unwrap();
     let guard = backend
@@ -221,6 +223,7 @@ async fn test_heartbeat_refreshes_lock() {
             max_hold_secs: 300,
             ..Default::default()
         },
+        false,
     )
     .unwrap();
 
@@ -258,6 +261,7 @@ async fn test_heartbeat_invalidates_guard_on_ownership_loss() {
             max_hold_secs: 300,
             ..Default::default()
         },
+        false,
     )
     .unwrap();
 
@@ -336,6 +340,7 @@ async fn test_release_skips_delete_when_ownership_lost() {
             max_hold_secs: 300,
             ..Default::default()
         },
+        false,
     )
     .unwrap();
 
@@ -403,6 +408,7 @@ async fn test_concurrent_contention_single_key() {
                     max_hold_secs: 300,
                     ..Default::default()
                 },
+                false,
             )
             .unwrap();
 
@@ -478,6 +484,7 @@ async fn test_concurrent_contention_overlapping_keys() {
                     max_hold_secs: 300,
                     ..Default::default()
                 },
+                false,
             )
             .unwrap();
 
@@ -513,6 +520,107 @@ async fn test_concurrent_contention_overlapping_keys() {
         1,
         "At most 1 task should hold the lock at any time"
     );
+}
+
+#[tokio::test]
+async fn test_lock_release_with_conditional_delete() {
+    let store = test_store("s3lock_cond_del_");
+    let backend = S3LockBackend::new(
+        store.clone(),
+        &S3LockConfig {
+            ttl_secs: 30,
+            max_retries: 0,
+            retry_delay_ms: 5,
+            max_hold_secs: 300,
+            ..Default::default()
+        },
+        true,
+    )
+    .unwrap();
+
+    let guard = backend
+        .acquire(&["cond_del_key".to_string()])
+        .await
+        .expect("Failed to acquire lock");
+
+    let lock_path = S3LockBackend::lock_path("cond_del_key");
+    store
+        .read(&lock_path)
+        .await
+        .expect("Lock object should exist after acquire");
+
+    guard.release().await;
+
+    let result = store.read(&lock_path).await;
+    assert_eq!(
+        result.unwrap_err().kind(),
+        ErrorKind::NotFound,
+        "Lock object should be deleted after conditional release"
+    );
+}
+
+/// Verifies that when another instance takes over a lock key before the original holder
+/// releases, the release does not delete the new owner's lock object.
+///
+/// This models the TOCTOU race that `supports_conditional_delete` is designed to guard
+/// against: instance A holds the lock, instance B force-writes a new lock payload
+/// (simulating lock recovery), and then A attempts to release. Because A's release logic
+/// reads the current payload and finds a foreign `instance_id`, it skips the delete and
+/// leaves B's object intact.
+#[tokio::test]
+async fn test_lock_release_conditional_delete_preserves_recovered_lock() {
+    let store = test_store("s3lock_cond_preserve_");
+    let backend_a = S3LockBackend::new(
+        store.clone(),
+        &S3LockConfig {
+            ttl_secs: 30,
+            max_retries: 0,
+            retry_delay_ms: 5,
+            max_hold_secs: 300,
+            ..Default::default()
+        },
+        true,
+    )
+    .unwrap();
+
+    let guard_a = backend_a
+        .acquire(&["contested_key".to_string()])
+        .await
+        .expect("Instance A failed to acquire lock");
+
+    let lock_path = S3LockBackend::lock_path("contested_key");
+
+    // Simulate instance B recovering and taking over the lock by unconditionally
+    // overwriting the lock object with B's own payload. This changes both the
+    // ETag and the instance_id stored in the lock file.
+    let instance_b_id = "instance-b-recovered";
+    let payload_b = S3LockPayload {
+        instance_id: instance_b_id.to_string(),
+        refreshed_at: Utc::now(),
+        ttl_secs: 30,
+    };
+    let data_b = serde_json::to_vec(&payload_b).unwrap();
+    store
+        .put_object(&lock_path, data_b)
+        .await
+        .expect("Instance B failed to overwrite lock");
+
+    // Instance A releases: its closure reads the current lock payload, finds B's
+    // instance_id, recognises that ownership has changed, and skips the delete.
+    guard_a.release().await;
+
+    // B's lock object must still exist — A must not have deleted it.
+    let surviving = store
+        .read(&lock_path)
+        .await
+        .expect("Instance B's lock should still exist after A's release");
+    let surviving_payload: S3LockPayload = serde_json::from_slice(&surviving).unwrap();
+    assert_eq!(
+        surviving_payload.instance_id, instance_b_id,
+        "Instance B's lock should not have been deleted by instance A's release"
+    );
+
+    let _ = store.delete(&lock_path).await;
 }
 
 #[test]

--- a/src/registry/metadata_store/mod.rs
+++ b/src/registry/metadata_store/mod.rs
@@ -33,7 +33,7 @@ use crate::registry::metadata_store::link_kind::LinkKind;
 pub struct ConditionalCapabilities {
     /// `PutObject` with `If-None-Match: *` — create-only, reject if object exists.
     pub put_if_none_match: bool,
-    /// `PutObject` with `If-Match: <etag>` — update-only, reject if ETag mismatch.
+    /// `PutObject` with `If-Match: <etag>` — update-only, reject if `ETag` mismatch.
     pub put_if_match: bool,
     /// `DeleteObject` with `If-Match: <etag>` — conditional delete.
     pub delete_if_match: bool,

--- a/src/registry/metadata_store/mod.rs
+++ b/src/registry/metadata_store/mod.rs
@@ -24,6 +24,28 @@ pub use lock::{LockStrategy, redis::LockConfig};
 
 use crate::registry::metadata_store::link_kind::LinkKind;
 
+/// Granular S3 conditional operation capabilities.
+///
+/// Each field corresponds to a distinct HTTP conditional header that the S3-compatible
+/// provider may or may not support. Configure these explicitly in `[metadata_store.s3.capabilities]`
+/// to skip the startup probe, or omit to auto-detect when using `lock_strategy = "s3"`.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ConditionalCapabilities {
+    /// `PutObject` with `If-None-Match: *` — create-only, reject if object exists.
+    pub put_if_none_match: bool,
+    /// `PutObject` with `If-Match: <etag>` — update-only, reject if ETag mismatch.
+    pub put_if_match: bool,
+    /// `DeleteObject` with `If-Match: <etag>` — conditional delete.
+    pub delete_if_match: bool,
+}
+
+impl ConditionalCapabilities {
+    /// Both conditional put operations are needed for CAS read-modify-write loops.
+    pub fn supports_cas(&self) -> bool {
+        self.put_if_none_match && self.put_if_match
+    }
+}
+
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BlobIndex {
     pub namespace: HashMap<String, HashSet<LinkKind>>,
@@ -206,6 +228,10 @@ pub trait MetadataStore: Send + Sync {
     ) -> Result<(), Error>;
 
     async fn flush_access_times(&self) {}
+
+    fn conditional_capabilities(&self) -> Option<ConditionalCapabilities> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/registry/metadata_store/mod.rs
+++ b/src/registry/metadata_store/mod.rs
@@ -20,7 +20,7 @@ pub mod s3;
 
 pub use config::MetadataStoreConfig;
 pub use link_metadata::LinkMetadata;
-pub use lock::redis::LockConfig;
+pub use lock::{LockStrategy, redis::LockConfig};
 
 use crate::registry::metadata_store::link_kind::LinkKind;
 

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -74,9 +74,9 @@ pub struct BackendConfig {
     pub access_time_debounce_secs: u64,
     /// Explicitly declare which conditional S3 operations the provider supports.
     /// Each boolean flag corresponds to a distinct HTTP conditional header:
-    /// - `put_if_none_match`: PutObject with If-None-Match: * (create-only)
-    /// - `put_if_match`: PutObject with If-Match: <etag> (update-only, enables CAS optimizations)
-    /// - `delete_if_match`: DeleteObject with If-Match: <etag> (atomic lock release)
+    /// - `put_if_none_match`: `PutObject` with If-None-Match: * (create-only)
+    /// - `put_if_match`: `PutObject` with If-Match: <etag> (update-only, enables CAS optimizations)
+    /// - `delete_if_match`: `DeleteObject` with If-Match: <etag> (atomic lock release)
     ///
     /// When set, the startup probe is skipped entirely and your declared values are used.
     /// When absent, the probe runs automatically if `lock_strategy = "s3"` to auto-detect

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -203,12 +203,17 @@ pub struct Backend {
     cache: Option<Arc<dyn Cache>>,
     link_cache_ttl: u64,
     access_time_writer: Option<AccessTimeWriter>,
+    /// Whether the S3 backend supports conditional writes (If-Match / If-None-Match).
+    /// When true, blob index updates use lock-free CAS. When false, they are protected
+    /// by the distributed lock alongside link updates.
+    supports_conditional_writes: bool,
     // Held for Drop side-effect: signals the flush task to exit when the last Backend is dropped.
     #[allow(dead_code)]
     flush_handle: Option<Arc<FlushHandle>>,
 }
 
 const MAX_UPDATE_RETRIES: u32 = 10;
+const MAX_BLOB_INDEX_CAS_RETRIES: u32 = 20;
 
 impl Backend {
     pub fn new(config: &BackendConfig) -> Result<Self, Error> {
@@ -243,6 +248,11 @@ impl Backend {
             }
         };
 
+        // S3 lock strategy probes conditional write support at startup, so if
+        // we're using S3 locks we know conditionals work. For other lock strategies
+        // the S3 backend may not support them (e.g. older S3-compatible stores).
+        let supports_conditional_writes = matches!(config.lock_strategy, LockStrategy::S3(_));
+
         if config.access_time_debounce_secs == 0
             && matches!(config.lock_strategy, LockStrategy::S3(_))
         {
@@ -271,6 +281,7 @@ impl Backend {
                 cache: None,
                 link_cache_ttl: config.link_cache_ttl,
                 access_time_writer: access_time_writer.clone(),
+                supports_conditional_writes,
                 flush_handle: None,
             };
 
@@ -295,6 +306,7 @@ impl Backend {
             cache: None,
             link_cache_ttl: config.link_cache_ttl,
             access_time_writer,
+            supports_conditional_writes,
             flush_handle,
         };
 
@@ -443,6 +455,85 @@ impl Backend {
                 .store_value(&Self::cache_key(namespace, link), "", 0)
                 .await;
         }
+    }
+
+    /// Applies a batch of blob index operations for a single digest using optimistic
+    /// concurrency (CAS). Reads the current blob index with its `ETag`, applies all
+    /// operations, and writes back with `If-Match`. Retries on `ETag` conflict.
+    ///
+    /// For new blob indexes (not-found), uses `If-None-Match: *` to create atomically,
+    /// falling back to CAS if another writer created the index concurrently.
+    async fn update_blob_index_cas(
+        &self,
+        namespace: &str,
+        digest: &Digest,
+        operations: &[BlobIndexOperation],
+    ) -> Result<(), Error> {
+        let path = path_builder::blob_index_path(digest);
+
+        for attempt in 0..MAX_BLOB_INDEX_CAS_RETRIES {
+            let (mut blob_index, etag) = match self.store.read_with_etag(&path).await {
+                Ok((data, etag)) => (serde_json::from_slice::<BlobIndex>(&data)?, etag),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => (BlobIndex::default(), None),
+                Err(e) => return Err(Error::from(e)),
+            };
+
+            apply_blob_index_ops(&mut blob_index, namespace, operations);
+
+            // Write the (possibly empty) index back with CAS. An empty index is written
+            // rather than deleted to avoid a race where a concurrent writer creates a new
+            // entry between our read and a non-conditional delete. The scrub command
+            // handles cleanup of empty blob containers.
+            let content = Bytes::from(serde_json::to_vec(&blob_index)?);
+
+            let write_result = if let Some(ref etag) = etag {
+                self.store
+                    .put_object_if_match(&path, etag, content)
+                    .await
+                    .map(|_| ())
+            } else {
+                self.store
+                    .put_object_if_not_exists(&path, content)
+                    .await
+                    .map(|_| ())
+            };
+
+            match write_result {
+                Ok(()) => return Ok(()),
+                Err(data_store::Error::PreconditionFailed) => {
+                    debug!(
+                        digest = %digest,
+                        attempt,
+                        "Blob index CAS conflict, retrying"
+                    );
+                    let jitter_ms = {
+                        use std::hash::{BuildHasher, Hasher};
+                        let max = 50u64.saturating_mul(1u64 << attempt.min(4));
+                        if max == 0 {
+                            0
+                        } else {
+                            std::collections::hash_map::RandomState::new()
+                                .build_hasher()
+                                .finish()
+                                % max
+                        }
+                    };
+                    tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+                }
+                Err(e) => return Err(Error::StorageBackend(e.to_string())),
+            }
+        }
+
+        warn!(
+            %digest,
+            namespace,
+            attempts = MAX_BLOB_INDEX_CAS_RETRIES,
+            "Blob index CAS retries exhausted; blob index may be incomplete for this namespace. \
+             A scrub run can reconcile the blob index."
+        );
+        Err(Error::Lock(format!(
+            "blob index CAS retries exhausted for digest {digest} after {MAX_BLOB_INDEX_CAS_RETRIES} attempts"
+        )))
     }
 }
 
@@ -657,6 +748,13 @@ impl MetadataStore for Backend {
         digest: &Digest,
         operation: BlobIndexOperation,
     ) -> Result<(), Error> {
+        if self.supports_conditional_writes {
+            return self
+                .update_blob_index_cas(namespace, digest, &[operation])
+                .await;
+        }
+
+        // Fallback: unconditional read-modify-write (caller must hold a lock).
         let path = path_builder::blob_index_path(digest);
 
         let mut reference_index = match self.store.read(&path).await {
@@ -665,27 +763,11 @@ impl MetadataStore for Backend {
             Err(e) => return Err(e.into()),
         };
 
-        let mut index = reference_index
-            .namespace
-            .remove(namespace)
-            .unwrap_or_default();
-        match operation {
-            BlobIndexOperation::Insert(link) => {
-                index.insert(link);
-            }
-            BlobIndexOperation::Remove(link) => {
-                index.remove(&link);
-            }
-        }
-        if !index.is_empty() {
-            reference_index
-                .namespace
-                .insert(namespace.to_string(), index);
-        }
+        apply_blob_index_ops(&mut reference_index, namespace, &[operation]);
 
         if reference_index.namespace.is_empty() {
-            let path = path_builder::blob_container_dir(digest);
-            self.store.delete_prefix(&path).await?;
+            let container = path_builder::blob_container_dir(digest);
+            self.store.delete_prefix(&container).await?;
         } else {
             let content = Bytes::from(serde_json::to_vec(&reference_index)?);
             self.store.put_object(&path, content).await?;
@@ -780,9 +862,11 @@ impl MetadataStore for Backend {
             }))
             .await;
 
-            // Lock keys include both link names and `blob:{digest}` for every target digest.
-            // This ensures blob index updates (which perform read-modify-write on per-digest
-            // index files) are serialized across concurrent update_links calls.
+            // When the S3 backend supports conditional writes, blob index updates use
+            // lock-free CAS (ETag-based compare-and-swap) and only link names are locked.
+            // Otherwise, `blob:{digest}` keys are included to serialize blob index
+            // read-modify-write cycles across concurrent callers.
+            let use_cas = self.supports_conditional_writes;
             let mut lock_keys: Vec<String> = Vec::new();
             let mut creates: Vec<(
                 LinkKind,
@@ -799,14 +883,18 @@ impl MetadataStore for Backend {
                     create_data
                 {
                     lock_keys.push(link.to_string());
-                    lock_keys.push(format!("blob:{target}"));
-                    if let Some(ref old) = old_target {
-                        lock_keys.push(format!("blob:{old}"));
+                    if !use_cas {
+                        lock_keys.push(format!("blob:{target}"));
+                        if let Some(ref old) = old_target {
+                            lock_keys.push(format!("blob:{old}"));
+                        }
                     }
                     creates.push((link, target, old_target, referrer, media_type, descriptor));
                 } else if let Some((link, Some(meta), referrer)) = delete_data {
                     lock_keys.push(link.to_string());
-                    lock_keys.push(format!("blob:{}", meta.target));
+                    if !use_cas {
+                        lock_keys.push(format!("blob:{}", meta.target));
+                    }
                     deletes.push((link, meta.target, referrer));
                 }
             }
@@ -1021,49 +1109,6 @@ impl MetadataStore for Backend {
                 return Err(Error::Lock("lock invalidated during operation".into()));
             }
 
-            // SAFETY: Blob index updates for different digests are independent (each digest
-            // has its own S3 key). Updates for the same digest within this call are grouped
-            // by the pending_blob_ops HashMap. Cross-call updates to the same digest are
-            // serialized by the `blob:{digest}` lock key acquired above.
-            join_all(pending_blob_ops.iter().map(|(digest, ops)| async move {
-                let path = path_builder::blob_index_path(digest);
-                let mut blob_index = match self.store.read(&path).await {
-                    Ok(data) => serde_json::from_slice::<BlobIndex>(&data)?,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => BlobIndex::default(),
-                    Err(e) => return Err(Error::from(e)),
-                };
-                let mut ns_links = blob_index.namespace.remove(namespace).unwrap_or_default();
-                for op in ops {
-                    match op {
-                        BlobIndexOperation::Insert(link) => {
-                            ns_links.insert(link.clone());
-                        }
-                        BlobIndexOperation::Remove(link) => {
-                            ns_links.remove(link);
-                        }
-                    }
-                }
-                if !ns_links.is_empty() {
-                    blob_index.namespace.insert(namespace.to_string(), ns_links);
-                }
-                if blob_index.namespace.is_empty() {
-                    let container = path_builder::blob_container_dir(digest);
-                    self.store.delete_prefix(&container).await?;
-                } else {
-                    let content = Bytes::from(serde_json::to_vec(&blob_index)?);
-                    self.store.put_object(&path, content).await?;
-                }
-                Ok(())
-            }))
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
-
-            if !guard.is_valid() {
-                guard.release().await;
-                return Err(Error::Lock("lock invalidated during operation".into()));
-            }
-
             for (link, metadata) in tracked_create_writes
                 .iter()
                 .chain(non_tracked_create_writes.iter())
@@ -1074,13 +1119,82 @@ impl MetadataStore for Backend {
                 self.cache_invalidate(namespace, link).await;
             }
 
-            guard.release().await;
+            if use_cas {
+                // Release the lock before blob index updates — CAS handles
+                // concurrency via ETags without requiring lock coordination.
+                guard.release().await;
+
+                // Blob index updates use optimistic concurrency (CAS via ETags) and
+                // run outside the lock. Each digest has its own S3 key, so updates to
+                // different digests are independent and can run in parallel. Concurrent
+                // updates from other callers are resolved by CAS retry.
+                join_all(
+                    pending_blob_ops
+                        .iter()
+                        .map(|(digest, ops)| self.update_blob_index_cas(namespace, digest, ops)),
+                )
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()?;
+            } else {
+                // Without conditional write support, blob index updates run under the
+                // lock (blob:{digest} keys are included in lock_keys above).
+                join_all(pending_blob_ops.iter().map(|(digest, ops)| async move {
+                    let path = path_builder::blob_index_path(digest);
+                    let mut blob_index = match self.store.read(&path).await {
+                        Ok(data) => serde_json::from_slice::<BlobIndex>(&data)?,
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => BlobIndex::default(),
+                        Err(e) => return Err(Error::from(e)),
+                    };
+                    apply_blob_index_ops(&mut blob_index, namespace, ops);
+                    if blob_index.namespace.is_empty() {
+                        let container = path_builder::blob_container_dir(digest);
+                        self.store.delete_prefix(&container).await?;
+                    } else {
+                        let content = Bytes::from(serde_json::to_vec(&blob_index)?);
+                        self.store.put_object(&path, content).await?;
+                    }
+                    Ok(())
+                }))
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()?;
+
+                if !guard.is_valid() {
+                    guard.release().await;
+                    return Err(Error::Lock("lock invalidated during operation".into()));
+                }
+
+                guard.release().await;
+            }
+
             return Ok(());
         }
     }
 
     async fn flush_access_times(&self) {
         Backend::flush_access_times(self).await;
+    }
+}
+
+fn apply_blob_index_ops(
+    blob_index: &mut BlobIndex,
+    namespace: &str,
+    operations: &[BlobIndexOperation],
+) {
+    let mut ns_links = blob_index.namespace.remove(namespace).unwrap_or_default();
+    for op in operations {
+        match op {
+            BlobIndexOperation::Insert(link) => {
+                ns_links.insert(link.clone());
+            }
+            BlobIndexOperation::Remove(link) => {
+                ns_links.remove(link);
+            }
+        }
+    }
+    if !ns_links.is_empty() {
+        blob_index.namespace.insert(namespace.to_string(), ns_links);
     }
 }
 

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -179,6 +186,16 @@ impl AccessTimeWriter {
     }
 }
 
+struct FlushHandle {
+    shutdown: Arc<AtomicBool>,
+}
+
+impl Drop for FlushHandle {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+    }
+}
+
 #[derive(Clone)]
 pub struct Backend {
     pub store: data_store::s3::Backend,
@@ -186,6 +203,9 @@ pub struct Backend {
     cache: Option<Arc<dyn Cache>>,
     link_cache_ttl: u64,
     access_time_writer: Option<AccessTimeWriter>,
+    // Held for Drop side-effect: signals the flush task to exit when the last Backend is dropped.
+    #[allow(dead_code)]
+    flush_handle: Option<Arc<FlushHandle>>,
 }
 
 const MAX_UPDATE_RETRIES: u32 = 10;
@@ -229,24 +249,43 @@ impl Backend {
             None
         };
 
+        let flush_handle = if config.access_time_debounce_secs > 0 {
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let shutdown_flag = shutdown.clone();
+            let interval = Duration::from_secs(config.access_time_debounce_secs);
+
+            let flush_backend = Self {
+                store: store.clone(),
+                lock: lock.clone(),
+                cache: None,
+                link_cache_ttl: config.link_cache_ttl,
+                access_time_writer: access_time_writer.clone(),
+                flush_handle: None,
+            };
+
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(interval).await;
+                    if shutdown_flag.load(Ordering::Acquire) {
+                        return;
+                    }
+                    flush_backend.flush_access_times().await;
+                }
+            });
+
+            Some(Arc::new(FlushHandle { shutdown }))
+        } else {
+            None
+        };
+
         let backend = Self {
             store,
             lock,
             cache: None,
             link_cache_ttl: config.link_cache_ttl,
             access_time_writer,
+            flush_handle,
         };
-
-        if config.access_time_debounce_secs > 0 {
-            let flush_backend = backend.clone();
-            let interval = Duration::from_secs(config.access_time_debounce_secs);
-            tokio::spawn(async move {
-                loop {
-                    tokio::time::sleep(interval).await;
-                    flush_backend.flush_access_times().await;
-                }
-            });
-        }
 
         Ok(backend)
     }

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -970,18 +970,127 @@ fn is_tracked_link(link: &LinkKind) -> bool {
 }
 
 impl Backend {
-    /// CAS-optimized write path: reads each link once under the lock (no pre-lock
-    /// reads), then releases the lock before CAS blob index updates. Eliminates
-    /// the redundant pre-lock read round trip that the non-CAS path requires for
-    /// blob digest lock key computation.
+    /// CAS-optimized write path with lock-free fast path for new links.
+    ///
+    /// Phase 1: For creates that produce fresh metadata (non-tracked, or tracked
+    /// without referrer), tries `If-None-Match: *` to atomically create the link
+    /// without a distributed lock. This avoids locking entirely for the common
+    /// case of fresh pushes where most links are new.
+    ///
+    /// Phase 2: For operations that need a lock (deletes, tracked creates with
+    /// referrer merging, creates where the link already existed), acquires the
+    /// lock and uses the standard read-modify-write flow.
+    ///
+    /// Phase 3: CAS blob index updates (always lock-free with conditional writes).
     #[allow(clippy::too_many_lines)]
     async fn update_links_cas(
         &self,
         namespace: &str,
         operations: &[LinkOperation],
     ) -> Result<(), Error> {
-        // Compute lock keys directly from operations — CAS blob index updates
-        // don't need blob:{digest} lock keys since they use ETag concurrency.
+        // Phase 1: Optimistic lock-free creation for eligible creates.
+        // Creates that produce fresh metadata (no referrer merge) can use
+        // If-None-Match:* to atomically create the link without locking.
+        let mut lockfree_blob_ops: HashMap<Digest, Vec<BlobIndexOperation>> = HashMap::new();
+        let mut lockfree_cache_puts: Vec<(LinkKind, LinkMetadata)> = Vec::new();
+        let mut locked_ops: Vec<LinkOperation> = Vec::new();
+        let mut any_creates = false;
+
+        let mut optimistic: Vec<(LinkOperation, LinkKind, Digest, LinkMetadata)> = Vec::new();
+
+        for op in operations {
+            match op {
+                LinkOperation::Create {
+                    link,
+                    target,
+                    referrer,
+                    media_type,
+                    descriptor,
+                } if !is_tracked_link(link) || referrer.is_none() => {
+                    any_creates = true;
+                    let metadata = LinkMetadata::from_digest(target.clone())
+                        .with_media_type(media_type.clone())
+                        .with_descriptor(descriptor.as_ref().clone());
+                    optimistic.push((op.clone(), link.clone(), target.clone(), metadata));
+                }
+                LinkOperation::Create { .. } => {
+                    any_creates = true;
+                    locked_ops.push(op.clone());
+                }
+                LinkOperation::Delete { .. } => {
+                    locked_ops.push(op.clone());
+                }
+            }
+        }
+
+        if !optimistic.is_empty() {
+            let results = join_all(optimistic.iter().map(|(_, link, _, metadata)| {
+                self.write_link_if_not_exists(namespace, link, metadata)
+            }))
+            .await;
+
+            for ((op, link, target, metadata), result) in optimistic.into_iter().zip(results) {
+                match result {
+                    Ok(true) => {
+                        lockfree_blob_ops
+                            .entry(target)
+                            .or_default()
+                            .push(BlobIndexOperation::Insert(link.clone()));
+                        lockfree_cache_puts.push((link, metadata));
+                    }
+                    Ok(false) => {
+                        locked_ops.push(op);
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+
+        // Phase 2: Locked path for remaining operations.
+        let locked_blob_ops = self
+            .execute_locked_cas_updates(namespace, &locked_ops)
+            .await?;
+
+        // Merge blob index operations from both paths.
+        let mut pending_blob_ops = lockfree_blob_ops;
+        for (digest, ops) in locked_blob_ops {
+            pending_blob_ops.entry(digest).or_default().extend(ops);
+        }
+
+        // Cache updates for lock-free writes.
+        for (link, metadata) in &lockfree_cache_puts {
+            self.cache_put(namespace, link, metadata).await;
+        }
+
+        // Phase 3: CAS blob index updates — ETags handle concurrency.
+        join_all(
+            pending_blob_ops
+                .iter()
+                .map(|(digest, ops)| self.update_blob_index_cas(namespace, digest, ops)),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+        if any_creates && let Err(e) = self.register_namespace(namespace).await {
+            warn!(namespace, error = %e, "Failed to register namespace");
+        }
+
+        Ok(())
+    }
+
+    /// Executes link operations under a distributed lock, returning pending
+    /// blob index operations for CAS updates after the lock is released.
+    #[allow(clippy::too_many_lines)]
+    async fn execute_locked_cas_updates(
+        &self,
+        namespace: &str,
+        operations: &[LinkOperation],
+    ) -> Result<HashMap<Digest, Vec<BlobIndexOperation>>, Error> {
+        if operations.is_empty() {
+            return Ok(HashMap::new());
+        }
+
         let mut lock_keys: Vec<String> = operations
             .iter()
             .map(|op| {
@@ -996,7 +1105,6 @@ impl Backend {
 
         let guard = self.lock.acquire(&lock_keys).await?;
 
-        // Single read per operation under the lock — no pre-lock reads needed.
         let read_results = join_all(operations.iter().map(|op| async move {
             let link = match op {
                 LinkOperation::Create { link, .. } | LinkOperation::Delete { link, .. } => link,
@@ -1043,7 +1151,7 @@ impl Backend {
 
         if creates.is_empty() && deletes.is_empty() {
             guard.release().await;
-            return Ok(());
+            return Ok(HashMap::new());
         }
 
         if !guard.is_valid() {
@@ -1110,25 +1218,9 @@ impl Backend {
             self.cache_invalidate(namespace, link).await;
         }
 
-        // Release lock before CAS blob index updates — ETags handle concurrency.
         guard.release().await;
 
-        join_all(
-            pending_blob_ops
-                .iter()
-                .map(|(digest, ops)| self.update_blob_index_cas(namespace, digest, ops)),
-        )
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?;
-
-        if !creates.is_empty()
-            && let Err(e) = self.register_namespace(namespace).await
-        {
-            warn!(namespace, error = %e, "Failed to register namespace");
-        }
-
-        Ok(())
+        Ok(pending_blob_ops)
     }
 
     /// Non-CAS write path: pre-lock reads to compute blob digest lock keys,
@@ -1829,6 +1921,28 @@ impl Backend {
             .put_object(&link_path, serialized_link_data)
             .await?;
         Ok(())
+    }
+
+    /// Atomically creates a link only if it does not already exist, using
+    /// S3 conditional `If-None-Match: *`. Returns `true` if the link was
+    /// created, `false` if it already existed (precondition failed).
+    async fn write_link_if_not_exists(
+        &self,
+        namespace: &str,
+        link: &LinkKind,
+        metadata: &LinkMetadata,
+    ) -> Result<bool, Error> {
+        let link_path = path_builder::link_path(link, namespace);
+        let serialized = Bytes::from(serde_json::to_vec(metadata)?);
+        match self
+            .store
+            .put_object_if_not_exists(&link_path, serialized)
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(data_store::Error::PreconditionFailed) => Ok(false),
+            Err(e) => Err(Error::StorageBackend(e.to_string())),
+        }
     }
 
     async fn delete_link_reference(&self, namespace: &str, link: &LinkKind) -> Result<(), Error> {

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -2436,9 +2436,7 @@ mod tests {
         backend.update_links(namespace, &ops).await.unwrap();
 
         for (i, digest) in digests.iter().enumerate() {
-            let path = path_builder::blob_index_path(digest);
-            let data = backend.store.read(&path).await.unwrap();
-            let blob_index: BlobIndex = serde_json::from_slice(&data).unwrap();
+            let blob_index = backend.read_blob_index(digest).await.unwrap();
             let ns_links = blob_index.namespace.get(namespace).unwrap();
             let expected_link = LinkKind::Tag(format!("tag-bim-{i}"));
             assert!(
@@ -2575,10 +2573,9 @@ mod tests {
                 "Tracked link {link} should be deleted"
             );
 
-            let path = path_builder::blob_index_path(d);
-            let result = backend.store.read(&path).await;
+            let result = backend.read_blob_index(d).await;
             assert!(
-                result.is_err(),
+                matches!(result, Err(Error::ReferenceNotFound)),
                 "Blob index for {d} should be removed after all links deleted"
             );
         }
@@ -2639,28 +2636,26 @@ mod tests {
         backend.update_links(namespace, &mixed_ops).await.unwrap();
 
         // Verify: keep-tag still exists
-        let keep_path = path_builder::blob_index_path(&digest_keep);
-        let keep_data = backend.store.read(&keep_path).await.unwrap();
-        let keep_index: BlobIndex = serde_json::from_slice(&keep_data).unwrap();
+        let keep_index = backend.read_blob_index(&digest_keep).await.unwrap();
         let keep_links = keep_index.namespace.get(namespace).unwrap();
         assert!(keep_links.contains(&LinkKind::Tag("keep-tag".into())));
 
         // Verify: remove-tag blob index no longer has it
-        let remove_path = path_builder::blob_index_path(&digest_remove);
-        let remove_result = backend.store.read(&remove_path).await;
-        if let Ok(data) = remove_result {
-            let idx: BlobIndex = serde_json::from_slice(&data).unwrap();
-            let links = idx.namespace.get(namespace);
-            assert!(
-                links.is_none() || !links.unwrap().contains(&LinkKind::Tag("remove-tag".into())),
-                "remove-tag should not be in blob index after delete"
-            );
+        match backend.read_blob_index(&digest_remove).await {
+            Ok(idx) => {
+                let links = idx.namespace.get(namespace);
+                assert!(
+                    links.is_none()
+                        || !links.unwrap().contains(&LinkKind::Tag("remove-tag".into())),
+                    "remove-tag should not be in blob index after delete"
+                );
+            }
+            Err(Error::ReferenceNotFound) => {}
+            Err(e) => panic!("Unexpected error reading blob index: {e}"),
         }
 
         // Verify: new-tag exists in digest_add's blob index
-        let add_path = path_builder::blob_index_path(&digest_add);
-        let add_data = backend.store.read(&add_path).await.unwrap();
-        let add_index: BlobIndex = serde_json::from_slice(&add_data).unwrap();
+        let add_index = backend.read_blob_index(&digest_add).await.unwrap();
         let add_links = add_index.namespace.get(namespace).unwrap();
         assert!(add_links.contains(&LinkKind::Tag("new-tag".into())));
 

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -299,7 +299,7 @@ impl Backend {
         // Step 5: Evaluate If-None-Match result
         match if_none_match_result {
             Err(data_store::Error::PreconditionFailed) => {}
-            Ok(()) => {
+            Ok(_) => {
                 return Err(Error::Lock(
                     "S3 backend does not support If-None-Match: * conditional writes, \
                      required for lock_strategy = s3. Use lock_strategy = redis or \
@@ -323,7 +323,7 @@ impl Backend {
             }
             match bogus_result {
                 Err(data_store::Error::PreconditionFailed) => {}
-                Ok(()) => {
+                Ok(_) => {
                     return Err(Error::Lock(
                         "S3 backend does not enforce If-Match: bogus ETag was accepted, \
                          required for lock heartbeat. Use lock_strategy = redis or \

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -1313,18 +1313,71 @@ impl Backend {
     }
 
     async fn read_namespace_registry(&self) -> Result<Option<NamespaceRegistry>, Error> {
-        let path = path_builder::namespace_registry_path();
-        match self.store.read(&path).await {
-            Ok(data) => match serde_json::from_slice(&data) {
-                Ok(registry) => Ok(Some(registry)),
-                Err(e) => {
-                    warn!("Corrupt namespace registry, will rebuild: {e}");
-                    Ok(None)
-                }
-            },
-            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(Error::from(e)),
+        // Read sharded format: list all shard files under _registry/ns/ and merge
+        let shard_dir = path_builder::namespace_registry_shard_dir();
+        let mut all_namespaces = Vec::new();
+        let mut found_shards = false;
+        let mut continuation_token = None;
+
+        loop {
+            let (_, objects, next_token) = self
+                .store
+                .list_prefixes(&shard_dir, "/", 1000, continuation_token, None)
+                .await?;
+
+            if !objects.is_empty() {
+                found_shards = true;
+            }
+
+            let shard_results: Vec<Result<Vec<String>, Error>> =
+                stream::iter(objects.into_iter().map(|obj| {
+                    let shard_path = format!("{shard_dir}/{obj}");
+                    async move {
+                        match self.store.read(&shard_path).await {
+                            Ok(data) => match serde_json::from_slice::<NamespaceRegistry>(&data) {
+                                Ok(registry) => Ok(registry.namespaces),
+                                Err(_) => Ok(Vec::new()),
+                            },
+                            Err(e) if e.kind() == ErrorKind::NotFound => Ok(Vec::new()),
+                            Err(e) => Err(Error::from(e)),
+                        }
+                    }
+                }))
+                .buffer_unordered(10)
+                .collect()
+                .await;
+
+            for result in shard_results {
+                all_namespaces.extend(result?);
+            }
+
+            continuation_token = next_token;
+            if continuation_token.is_none() {
+                break;
+            }
         }
+
+        if !found_shards {
+            // Fall back to legacy single-file format for backward compatibility
+            let path = path_builder::namespace_registry_path();
+            return match self.store.read(&path).await {
+                Ok(data) => match serde_json::from_slice(&data) {
+                    Ok(registry) => Ok(Some(registry)),
+                    Err(e) => {
+                        warn!("Corrupt namespace registry, will rebuild: {e}");
+                        Ok(None)
+                    }
+                },
+                Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(Error::from(e)),
+            };
+        }
+
+        all_namespaces.sort();
+        all_namespaces.dedup();
+        Ok(Some(NamespaceRegistry {
+            namespaces: all_namespaces,
+        }))
     }
 
     pub async fn rebuild_namespace_registry(&self) -> Result<(), Error> {
@@ -1335,42 +1388,59 @@ impl Backend {
         namespaces.sort();
         namespaces.dedup();
 
-        let registry = NamespaceRegistry { namespaces };
-        let content = Bytes::from(serde_json::to_vec(&registry)?);
-        let path = path_builder::namespace_registry_path();
-
-        if self.supports_conditional_writes {
-            // Use CAS to avoid stomping concurrent register_namespace_cas writes.
-            // Read current ETag (if any), then write with If-Match / If-None-Match.
-            let etag = match self.store.read_with_etag(&path).await {
-                Ok((_, etag)) => etag,
-                Err(e) if e.kind() == ErrorKind::NotFound => None,
-                Err(e) => return Err(Error::from(e)),
-            };
-            let write_result = if let Some(ref etag) = etag {
-                self.store
-                    .put_object_if_match(&path, etag, content)
-                    .await
-                    .map(|_| ())
-            } else {
-                self.store
-                    .put_object_if_not_exists(&path, content)
-                    .await
-                    .map(|_| ())
-            };
-            match write_result {
-                Ok(()) => {}
-                Err(data_store::Error::PreconditionFailed) => {
-                    debug!("Namespace registry rebuild lost CAS race; concurrent write wins");
-                }
-                Err(e) => return Err(Error::StorageBackend(e.to_string())),
-            }
-        } else {
-            let lock_key = "namespace_registry".to_string();
-            let guard = self.lock.acquire(&[lock_key]).await?;
-            self.store.put_object(&path, content).await?;
-            guard.release().await;
+        // Group namespaces by shard key
+        let mut shards: HashMap<String, Vec<String>> = HashMap::new();
+        for ns in &namespaces {
+            let key = path_builder::namespace_shard_key(ns);
+            shards.entry(key).or_default().push(ns.clone());
         }
+
+        // Write each shard
+        for (shard_key, shard_namespaces) in &shards {
+            let registry = NamespaceRegistry {
+                namespaces: shard_namespaces.clone(),
+            };
+            let content = Bytes::from(serde_json::to_vec(&registry)?);
+            let path = format!(
+                "{}/{shard_key}.json",
+                path_builder::namespace_registry_shard_dir()
+            );
+
+            if self.supports_conditional_writes {
+                let etag = match self.store.read_with_etag(&path).await {
+                    Ok((_, etag)) => etag,
+                    Err(e) if e.kind() == ErrorKind::NotFound => None,
+                    Err(e) => return Err(Error::from(e)),
+                };
+                let write_result = if let Some(ref etag) = etag {
+                    self.store
+                        .put_object_if_match(&path, etag, content)
+                        .await
+                        .map(|_| ())
+                } else {
+                    self.store
+                        .put_object_if_not_exists(&path, content)
+                        .await
+                        .map(|_| ())
+                };
+                match write_result {
+                    Ok(()) => {}
+                    Err(data_store::Error::PreconditionFailed) => {
+                        debug!(
+                            shard_key,
+                            "Namespace registry shard rebuild lost CAS race; concurrent write wins"
+                        );
+                    }
+                    Err(e) => return Err(Error::StorageBackend(e.to_string())),
+                }
+            } else {
+                let lock_key = format!("namespace_registry_shard_{shard_key}");
+                let guard = self.lock.acquire(&[lock_key]).await?;
+                self.store.put_object(&path, content).await?;
+                guard.release().await;
+            }
+        }
+
         Ok(())
     }
 
@@ -1387,8 +1457,9 @@ impl Backend {
     }
 
     async fn register_namespace_unconditional(&self, namespace: &str) -> Result<(), Error> {
-        let path = path_builder::namespace_registry_path();
-        let lock_key = "namespace_registry".to_string();
+        let shard_key = path_builder::namespace_shard_key(namespace);
+        let path = path_builder::namespace_registry_shard_path(namespace);
+        let lock_key = format!("namespace_registry_shard_{shard_key}");
         let guard = self.lock.acquire(&[lock_key]).await?;
 
         let mut registry = match self.store.read(&path).await {
@@ -1418,13 +1489,12 @@ impl Backend {
     }
 
     async fn register_namespace_cas(&self, namespace: &str) -> Result<(), Error> {
-        let path = path_builder::namespace_registry_path();
+        let path = path_builder::namespace_registry_shard_path(namespace);
 
         for attempt in 0..MAX_BLOB_INDEX_CAS_RETRIES {
             let (mut registry, etag) = match self.store.read_with_etag(&path).await {
                 Ok((data, etag)) => match serde_json::from_slice::<NamespaceRegistry>(&data) {
                     Ok(r) => (r, etag),
-                    // Corrupt JSON: keep the ETag so we can overwrite with CAS
                     Err(_) => (NamespaceRegistry::default(), etag),
                 },
                 Err(e) if e.kind() == ErrorKind::NotFound => (NamespaceRegistry::default(), None),
@@ -1464,7 +1534,7 @@ impl Backend {
                 Err(data_store::Error::PreconditionFailed) => {
                     debug!(
                         namespace,
-                        attempt, "Namespace registry CAS conflict, retrying"
+                        attempt, "Namespace registry shard CAS conflict, retrying"
                     );
                     let jitter_ms = {
                         let max = 50u64.saturating_mul(1u64 << attempt.min(4));
@@ -1482,7 +1552,7 @@ impl Backend {
 
         warn!(
             namespace,
-            "Namespace registry CAS retries exhausted; namespace will appear after scrub reconciles"
+            "Namespace registry shard CAS retries exhausted; namespace will appear after scrub reconciles"
         );
         Ok(())
     }

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         data_store,
         metadata_store::{
             BlobIndex, BlobIndexOperation, Error, LinkMetadata, LinkOperation, LockConfig,
-            MetadataStore,
+            LockStrategy, MetadataStore,
             link_kind::LinkKind,
             lock::{self, LockBackend, MemoryBackend},
         },
@@ -25,21 +25,75 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BackendConfig {
     pub access_key_id: String,
     pub secret_key: String,
     pub endpoint: String,
     pub bucket: String,
     pub region: String,
-    #[serde(default)]
     pub key_prefix: String,
-    #[serde(default)]
-    pub redis: Option<LockConfig>,
-    #[serde(default = "default_link_cache_ttl")]
+    pub lock_strategy: LockStrategy,
     pub link_cache_ttl: u64,
-    #[serde(default = "default_access_time_debounce")]
     pub access_time_debounce_secs: u64,
+}
+
+impl Default for BackendConfig {
+    fn default() -> Self {
+        Self {
+            access_key_id: String::new(),
+            secret_key: String::new(),
+            endpoint: String::new(),
+            bucket: String::new(),
+            region: String::new(),
+            key_prefix: String::new(),
+            lock_strategy: LockStrategy::Memory,
+            link_cache_ttl: default_link_cache_ttl(),
+            access_time_debounce_secs: default_access_time_debounce(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BackendConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            access_key_id: String,
+            secret_key: String,
+            endpoint: String,
+            bucket: String,
+            region: String,
+            #[serde(default)]
+            key_prefix: String,
+            #[serde(default)]
+            redis: Option<LockConfig>,
+            #[serde(default)]
+            lock_strategy: Option<LockStrategy>,
+            #[serde(default = "default_link_cache_ttl")]
+            link_cache_ttl: u64,
+            #[serde(default = "default_access_time_debounce")]
+            access_time_debounce_secs: u64,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+
+        let lock_strategy = lock::resolve_lock_strategy(raw.lock_strategy, raw.redis, true)?;
+
+        Ok(BackendConfig {
+            access_key_id: raw.access_key_id,
+            secret_key: raw.secret_key,
+            endpoint: raw.endpoint,
+            bucket: raw.bucket,
+            region: raw.region,
+            key_prefix: raw.key_prefix,
+            lock_strategy,
+            link_cache_ttl: raw.link_cache_ttl,
+            access_time_debounce_secs: raw.access_time_debounce_secs,
+        })
+    }
 }
 
 fn default_link_cache_ttl() -> u64 {
@@ -100,7 +154,7 @@ impl AccessTimeWriter {
     }
 
     async fn flush_one(backend: &Backend, namespace: &str, link: &LinkKind) -> Result<(), Error> {
-        let _guard = backend.lock.acquire(&[link.to_string()]).await?;
+        let guard = backend.lock.acquire(&[link.to_string()]).await?;
         let link_data = backend
             .read_link_reference(namespace, link)
             .await?
@@ -108,6 +162,7 @@ impl AccessTimeWriter {
         backend
             .write_link_reference(namespace, link, &link_data)
             .await?;
+        guard.release().await;
         Ok(())
     }
 }
@@ -115,7 +170,7 @@ impl AccessTimeWriter {
 #[derive(Clone)]
 pub struct Backend {
     pub store: data_store::s3::Backend,
-    lock: Arc<dyn LockBackend<Guard = Box<dyn Send>> + Send + Sync>,
+    lock: Arc<dyn LockBackend + Send + Sync>,
     cache: Option<Arc<dyn Cache>>,
     link_cache_ttl: u64,
     access_time_writer: Option<AccessTimeWriter>,
@@ -134,17 +189,28 @@ impl Backend {
             ..Default::default()
         })?;
 
-        let lock: Arc<dyn LockBackend<Guard = Box<dyn Send>> + Send + Sync> =
-            if let Some(redis_config) = &config.redis {
+        let lock: Arc<dyn LockBackend + Send + Sync> = match &config.lock_strategy {
+            LockStrategy::Redis(redis_config) => {
                 info!("Using Redis lock store for S3 metadata-store");
                 let backend = lock::RedisBackend::new(redis_config).map_err(|e| {
                     Error::Lock(format!("Failed to initialize Redis lock store: {e}"))
                 })?;
                 Arc::new(backend)
-            } else {
+            }
+            LockStrategy::S3(s3_lock_config) => {
+                info!("Using S3 lock store for S3 metadata-store");
+                let lock_store = Arc::new(store.clone());
+                Arc::new(
+                    lock::S3LockBackend::new(lock_store, s3_lock_config).map_err(|e| {
+                        Error::Lock(format!("Failed to initialize S3 lock store: {e}"))
+                    })?,
+                )
+            }
+            LockStrategy::Memory => {
                 info!("Using in-memory lock store for S3 metadata-store");
                 Arc::new(MemoryBackend::new())
-            };
+            }
+        };
 
         let access_time_writer = if config.access_time_debounce_secs > 0 {
             Some(AccessTimeWriter::new())
@@ -172,6 +238,100 @@ impl Backend {
         }
 
         Ok(backend)
+    }
+
+    pub async fn probe_conditional_write_support(
+        store: &data_store::s3::Backend,
+    ) -> Result<(), Error> {
+        let probe_key = format!("_angos_probe_{}", uuid::Uuid::new_v4());
+        let content: &[u8] = b"probe";
+
+        // Step 1: PUT the probe object
+        if let Err(e) = store.put_object(&probe_key, content).await {
+            let _ = store.delete(&probe_key).await;
+            return Err(Error::Lock(format!(
+                "S3 conditional write probe failed to create probe object: {e}"
+            )));
+        }
+
+        // Step 2: PUT again with If-None-Match: * — expect 412 PreconditionFailed
+        let if_none_match_result = store.put_object_if_not_exists(&probe_key, content).await;
+
+        // Step 3: Test If-Match — read current ETag, update should succeed
+        let if_match_result = match store.read_with_etag(&probe_key).await {
+            Ok((_, Some(etag))) => {
+                let update_result = store
+                    .put_object_if_match(&probe_key, &etag, b"updated".to_vec())
+                    .await;
+                let bogus_result = store
+                    .put_object_if_match(&probe_key, "\"bogus\"", b"fail".to_vec())
+                    .await;
+                Some((update_result, bogus_result))
+            }
+            Ok((_, None)) => {
+                let _ = store.delete(&probe_key).await;
+                return Err(Error::Lock(
+                    "S3 conditional write probe: ETag not returned, \
+                     If-Match support cannot be verified"
+                        .to_string(),
+                ));
+            }
+            Err(e) => {
+                let _ = store.delete(&probe_key).await;
+                return Err(Error::Lock(format!(
+                    "S3 conditional write probe failed to read probe object for If-Match test: {e}"
+                )));
+            }
+        };
+
+        // Step 4: Clean up probe object regardless of outcome
+        let _ = store.delete(&probe_key).await;
+
+        // Step 5: Evaluate If-None-Match result
+        match if_none_match_result {
+            Err(data_store::Error::PreconditionFailed) => {}
+            Ok(()) => {
+                return Err(Error::Lock(
+                    "S3 backend does not support If-None-Match: * conditional writes, \
+                     required for lock_strategy = s3. Use lock_strategy = redis or \
+                     lock_strategy = memory instead."
+                        .to_string(),
+                ));
+            }
+            Err(e) => {
+                return Err(Error::Lock(format!(
+                    "S3 conditional write probe (If-None-Match) failed: {e}"
+                )));
+            }
+        }
+
+        // Step 6: Evaluate If-Match results
+        if let Some((update_result, bogus_result)) = if_match_result {
+            if let Err(e) = update_result {
+                return Err(Error::Lock(format!(
+                    "S3 backend does not support If-Match conditional writes (update failed): {e}"
+                )));
+            }
+            match bogus_result {
+                Err(data_store::Error::PreconditionFailed) => {}
+                Ok(()) => {
+                    return Err(Error::Lock(
+                        "S3 backend does not enforce If-Match: bogus ETag was accepted, \
+                         required for lock heartbeat. Use lock_strategy = redis or \
+                         lock_strategy = memory instead."
+                            .to_string(),
+                    ));
+                }
+                Err(e) => {
+                    return Err(Error::Lock(format!(
+                        "S3 conditional write probe (If-Match bogus) failed unexpectedly: {e}"
+                    )));
+                }
+            }
+        }
+
+        info!("S3 conditional write probe passed (If-None-Match and If-Match supported)");
+        Ok(())
     }
 
     pub async fn flush_access_times(&self) {
@@ -492,11 +652,12 @@ impl MetadataStore for Backend {
                 writer.record(namespace, link).await;
                 Ok(link_data)
             } else {
-                let _guard = self.lock.acquire(&[link.to_string()]).await?;
+                let guard = self.lock.acquire(&[link.to_string()]).await?;
                 let link_data = self.read_link_reference(namespace, link).await?.accessed();
                 self.write_link_reference(namespace, link, &link_data)
                     .await?;
                 self.cache_put(namespace, link, &link_data).await;
+                guard.release().await;
                 Ok(link_data)
             }
         } else {
@@ -591,7 +752,7 @@ impl MetadataStore for Backend {
 
             lock_keys.sort();
             lock_keys.dedup();
-            let _guard = self.lock.acquire(&lock_keys).await?;
+            let guard = self.lock.acquire(&lock_keys).await?;
 
             let validation_results = join_all(creates.iter().map(
                 |(link, _, expected_old, _, _, _)| async move {
@@ -606,12 +767,18 @@ impl MetadataStore for Backend {
                 .iter()
                 .any(|(_, _, current_target, expected)| *current_target != *expected)
             {
+                guard.release().await;
                 continue;
             }
             for (link, metadata, _, _) in validation_results {
                 if let Some(m) = metadata {
                     link_cache.insert(link, m);
                 }
+            }
+
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
             }
 
             let delete_results =
@@ -638,6 +805,7 @@ impl MetadataStore for Backend {
                 }
             }
             if needs_retry {
+                guard.release().await;
                 continue;
             }
 
@@ -688,6 +856,11 @@ impl MetadataStore for Backend {
                     ));
                 }
             }
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
+            }
+
             join_all(
                 tracked_create_writes
                     .iter()
@@ -730,6 +903,11 @@ impl MetadataStore for Backend {
                         .push(BlobIndexOperation::Remove(link.clone()));
                 }
             }
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
+            }
+
             join_all(
                 tracked_delete_writes
                     .iter()
@@ -758,6 +936,11 @@ impl MetadataStore for Backend {
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
+
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
+            }
 
             join_all(pending_blob_ops.iter().map(|(digest, ops)| async move {
                 let path = path_builder::blob_index_path(digest);
@@ -793,6 +976,11 @@ impl MetadataStore for Backend {
             .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
 
+            if !guard.is_valid() {
+                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
+            }
+
             for (link, metadata) in tracked_create_writes
                 .iter()
                 .chain(non_tracked_create_writes.iter())
@@ -803,6 +991,7 @@ impl MetadataStore for Backend {
                 self.cache_invalidate(namespace, link).await;
             }
 
+            guard.release().await;
             return Ok(());
         }
     }
@@ -910,7 +1099,7 @@ mod tests {
             region: "region".to_string(),
             bucket: "registry".to_string(),
             key_prefix: format!("test-cache-{}", uuid::Uuid::new_v4()),
-            redis: None,
+            lock_strategy: LockStrategy::Memory,
             link_cache_ttl: 30,
             access_time_debounce_secs: 0,
         }
@@ -1983,6 +2172,27 @@ mod tests {
         assert!(
             !pending.is_empty(),
             "writer.record() should have been called even on cache hit"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_probe_conditional_write_support() {
+        let config = test_config();
+        let store = data_store::s3::Backend::new(&data_store::s3::BackendConfig {
+            access_key_id: config.access_key_id.clone(),
+            secret_key: config.secret_key.clone(),
+            endpoint: config.endpoint.clone(),
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+            key_prefix: config.key_prefix.clone(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let result = Backend::probe_conditional_write_support(&store).await;
+        assert!(
+            result.is_ok(),
+            "Probe should pass on MinIO (supports If-None-Match): {result:?}"
         );
     }
 }

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -13,7 +13,7 @@ use futures_util::{
     future::join_all,
     stream::{self, StreamExt},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::{debug, info, instrument, warn};
 
@@ -201,6 +201,11 @@ impl Drop for FlushHandle {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct NamespaceRegistry {
+    namespaces: Vec<String>,
+}
+
 #[derive(Clone)]
 pub struct Backend {
     pub store: data_store::s3::Backend,
@@ -212,6 +217,7 @@ pub struct Backend {
     /// When true, blob index updates use lock-free CAS. When false, they are protected
     /// by the distributed lock alongside link updates.
     supports_conditional_writes: bool,
+    known_namespaces: Arc<Mutex<HashSet<String>>>,
     // Held for Drop side-effect: signals the flush task to exit when the last Backend is dropped.
     #[allow(dead_code)]
     flush_handle: Option<Arc<FlushHandle>>,
@@ -287,6 +293,7 @@ impl Backend {
                 link_cache_ttl: config.link_cache_ttl,
                 access_time_writer: access_time_writer.clone(),
                 supports_conditional_writes,
+                known_namespaces: Arc::new(Mutex::new(HashSet::new())),
                 flush_handle: None,
             };
 
@@ -312,6 +319,7 @@ impl Backend {
             link_cache_ttl: config.link_cache_ttl,
             access_time_writer,
             supports_conditional_writes,
+            known_namespaces: Arc::new(Mutex::new(HashSet::new())),
             flush_handle,
         };
 
@@ -552,11 +560,21 @@ impl MetadataStore for Backend {
     ) -> Result<(Vec<String>, Option<String>), Error> {
         debug!("Fetching {n} namespace(s) with continuation token: {last:?}");
 
-        let repo_dir = path_builder::repository_dir();
-        let mut namespaces = Vec::new();
-        self.collect_namespaces(repo_dir, "", &mut namespaces)
-            .await?;
-        namespaces.sort();
+        let namespaces = if let Some(registry) = self.read_namespace_registry().await? {
+            registry.namespaces
+        } else {
+            info!("Namespace registry not found, rebuilding from S3 tree walk");
+            self.rebuild_namespace_registry().await?;
+            self.read_namespace_registry()
+                .await?
+                .map(|r| r.namespaces)
+                .unwrap_or_default()
+        };
+
+        {
+            let mut cache = self.known_namespaces.lock().await;
+            cache.extend(namespaces.iter().cloned());
+        }
 
         Ok(pagination::paginate_sorted(&namespaces, n, last.as_deref()))
     }
@@ -1178,6 +1196,12 @@ impl MetadataStore for Backend {
                 guard.release().await;
             }
 
+            if !creates.is_empty()
+                && let Err(e) = self.register_namespace(namespace).await
+            {
+                warn!(namespace, error = %e, "Failed to register namespace");
+            }
+
             return Ok(());
         }
     }
@@ -1216,6 +1240,172 @@ fn is_tracked_link(link: &LinkKind) -> bool {
 }
 
 impl Backend {
+    async fn read_namespace_registry(&self) -> Result<Option<NamespaceRegistry>, Error> {
+        let path = path_builder::namespace_registry_path();
+        match self.store.read(&path).await {
+            Ok(data) => match serde_json::from_slice(&data) {
+                Ok(registry) => Ok(Some(registry)),
+                Err(e) => {
+                    warn!("Corrupt namespace registry, will rebuild: {e}");
+                    Ok(None)
+                }
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+
+    pub async fn rebuild_namespace_registry(&self) -> Result<(), Error> {
+        let repo_dir = path_builder::repository_dir();
+        let mut namespaces = Vec::new();
+        self.collect_namespaces(repo_dir, "", &mut namespaces)
+            .await?;
+        namespaces.sort();
+        namespaces.dedup();
+
+        let registry = NamespaceRegistry { namespaces };
+        let content = Bytes::from(serde_json::to_vec(&registry)?);
+        let path = path_builder::namespace_registry_path();
+
+        if self.supports_conditional_writes {
+            self.store.put_object(&path, content).await?;
+        } else {
+            let lock_key = "namespace_registry".to_string();
+            let guard = self.lock.acquire(&[lock_key]).await?;
+            self.store.put_object(&path, content).await?;
+            guard.release().await;
+        }
+        Ok(())
+    }
+
+    async fn register_namespace(&self, namespace: &str) -> Result<(), Error> {
+        if self.known_namespaces.lock().await.contains(namespace) {
+            return Ok(());
+        }
+
+        if self.supports_conditional_writes {
+            self.register_namespace_cas(namespace).await
+        } else {
+            self.register_namespace_unconditional(namespace).await
+        }
+    }
+
+    async fn register_namespace_unconditional(&self, namespace: &str) -> Result<(), Error> {
+        let path = path_builder::namespace_registry_path();
+        let lock_key = "namespace_registry".to_string();
+        let guard = self.lock.acquire(&[lock_key]).await?;
+
+        let mut registry = match self.store.read(&path).await {
+            Ok(data) => serde_json::from_slice::<NamespaceRegistry>(&data).unwrap_or_default(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => NamespaceRegistry::default(),
+            Err(e) => {
+                guard.release().await;
+                return Err(Error::from(e));
+            }
+        };
+
+        if let Err(pos) = registry.namespaces.binary_search(&namespace.to_string()) {
+            registry.namespaces.insert(pos, namespace.to_string());
+            let content = Bytes::from(serde_json::to_vec(&registry)?);
+            if let Err(e) = self.store.put_object(&path, content).await {
+                guard.release().await;
+                return Err(e.into());
+            }
+        }
+
+        guard.release().await;
+        self.known_namespaces
+            .lock()
+            .await
+            .insert(namespace.to_string());
+        Ok(())
+    }
+
+    async fn register_namespace_cas(&self, namespace: &str) -> Result<(), Error> {
+        let path = path_builder::namespace_registry_path();
+
+        for attempt in 0..MAX_BLOB_INDEX_CAS_RETRIES {
+            let (mut registry, etag) = match self.store.read_with_etag(&path).await {
+                Ok((data, etag)) => match serde_json::from_slice::<NamespaceRegistry>(&data) {
+                    Ok(r) => (r, etag),
+                    // Corrupt JSON: keep the ETag so we can overwrite with CAS
+                    Err(_) => (NamespaceRegistry::default(), etag),
+                },
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    (NamespaceRegistry::default(), None)
+                }
+                Err(e) => return Err(Error::from(e)),
+            };
+
+            if registry
+                .namespaces
+                .binary_search(&namespace.to_string())
+                .is_ok()
+            {
+                self.known_namespaces
+                    .lock()
+                    .await
+                    .insert(namespace.to_string());
+                return Ok(());
+            }
+
+            let pos = registry
+                .namespaces
+                .binary_search(&namespace.to_string())
+                .unwrap_err();
+            registry.namespaces.insert(pos, namespace.to_string());
+
+            let content = Bytes::from(serde_json::to_vec(&registry)?);
+            let write_result = if let Some(ref etag) = etag {
+                self.store
+                    .put_object_if_match(&path, etag, content)
+                    .await
+                    .map(|_| ())
+            } else {
+                self.store
+                    .put_object_if_not_exists(&path, content)
+                    .await
+                    .map(|_| ())
+            };
+
+            match write_result {
+                Ok(()) => {
+                    self.known_namespaces
+                        .lock()
+                        .await
+                        .insert(namespace.to_string());
+                    return Ok(());
+                }
+                Err(data_store::Error::PreconditionFailed) => {
+                    debug!(
+                        namespace,
+                        attempt, "Namespace registry CAS conflict, retrying"
+                    );
+                    let jitter_ms = {
+                        use std::hash::{BuildHasher, Hasher};
+                        let max = 50u64.saturating_mul(1u64 << attempt.min(4));
+                        if max == 0 {
+                            0
+                        } else {
+                            std::collections::hash_map::RandomState::new()
+                                .build_hasher()
+                                .finish()
+                                % max
+                        }
+                    };
+                    tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+                }
+                Err(e) => return Err(Error::StorageBackend(e.to_string())),
+            }
+        }
+
+        warn!(
+            namespace,
+            "Namespace registry CAS retries exhausted; namespace will appear after scrub reconciles"
+        );
+        Ok(())
+    }
+
     async fn collect_namespaces(
         &self,
         path: &str,

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -178,6 +178,11 @@ impl AccessTimeWriter {
             .read_link_reference(namespace, link)
             .await?
             .accessed();
+        if !guard.is_valid() {
+            return Err(Error::Lock(
+                "lock invalidated during access time flush".into(),
+            ));
+        }
         backend
             .write_link_reference(namespace, link, &link_data)
             .await?;
@@ -797,6 +802,11 @@ impl MetadataStore for Backend {
             } else {
                 let guard = self.lock.acquire(&[link.to_string()]).await?;
                 let link_data = self.read_link_reference(namespace, link).await?.accessed();
+                if !guard.is_valid() {
+                    return Err(Error::Lock(
+                        "lock invalidated during access time update".into(),
+                    ));
+                }
                 self.write_link_reference(namespace, link, &link_data)
                     .await?;
                 self.cache_put(namespace, link, &link_data).await;

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -36,6 +36,31 @@ use crate::{
     },
 };
 
+/// A single create operation tuple.
+type CreateOp = (
+    LinkKind,
+    Digest,
+    Option<Digest>,
+    Option<Digest>,
+    Option<String>,
+    Option<Descriptor>,
+);
+
+/// Return type of `build_create_ops`.
+type CreateOpsResult = (
+    HashMap<Digest, Vec<BlobIndexOperation>>,
+    Vec<(LinkKind, LinkMetadata)>,
+    Vec<(LinkKind, LinkMetadata)>,
+);
+
+/// Return type of `build_delete_ops`.
+type DeleteOpsResult = (
+    HashMap<Digest, Vec<BlobIndexOperation>>,
+    Vec<(LinkKind, LinkMetadata)>,
+    Vec<LinkKind>,
+    Vec<LinkKind>,
+);
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct BackendConfig {
     pub access_key_id: String,
@@ -925,6 +950,196 @@ impl MetadataStore for Backend {
             return Ok(());
         }
 
+        if self.supports_conditional_writes {
+            self.update_links_cas(namespace, operations).await
+        } else {
+            self.update_links_locked(namespace, operations).await
+        }
+    }
+
+    async fn flush_access_times(&self) {
+        Backend::flush_access_times(self).await;
+    }
+}
+
+fn is_tracked_link(link: &LinkKind) -> bool {
+    matches!(
+        link,
+        LinkKind::Layer(_) | LinkKind::Config(_) | LinkKind::Manifest(_, _)
+    )
+}
+
+impl Backend {
+    /// CAS-optimized write path: reads each link once under the lock (no pre-lock
+    /// reads), then releases the lock before CAS blob index updates. Eliminates
+    /// the redundant pre-lock read round trip that the non-CAS path requires for
+    /// blob digest lock key computation.
+    #[allow(clippy::too_many_lines)]
+    async fn update_links_cas(
+        &self,
+        namespace: &str,
+        operations: &[LinkOperation],
+    ) -> Result<(), Error> {
+        // Compute lock keys directly from operations — CAS blob index updates
+        // don't need blob:{digest} lock keys since they use ETag concurrency.
+        let mut lock_keys: Vec<String> = operations
+            .iter()
+            .map(|op| {
+                let link = match op {
+                    LinkOperation::Create { link, .. } | LinkOperation::Delete { link, .. } => link,
+                };
+                format!("{namespace}:{link}")
+            })
+            .collect();
+        lock_keys.sort();
+        lock_keys.dedup();
+
+        let guard = self.lock.acquire(&lock_keys).await?;
+
+        // Single read per operation under the lock — no pre-lock reads needed.
+        let read_results = join_all(operations.iter().map(|op| async move {
+            let link = match op {
+                LinkOperation::Create { link, .. } | LinkOperation::Delete { link, .. } => link,
+            };
+            let metadata = self.read_link_reference(namespace, link).await.ok();
+            (op, metadata)
+        }))
+        .await;
+
+        let mut link_cache: HashMap<LinkKind, LinkMetadata> = HashMap::new();
+        let mut creates: Vec<CreateOp> = Vec::new();
+        let mut deletes: Vec<(LinkKind, Digest, Option<Digest>)> = Vec::new();
+
+        for (op, metadata) in &read_results {
+            match op {
+                LinkOperation::Create {
+                    link,
+                    target,
+                    referrer,
+                    media_type,
+                    descriptor,
+                } => {
+                    let old_target = metadata.as_ref().map(|m| m.target.clone());
+                    if let Some(m) = metadata {
+                        link_cache.insert(link.clone(), m.clone());
+                    }
+                    creates.push((
+                        link.clone(),
+                        target.clone(),
+                        old_target,
+                        referrer.clone(),
+                        media_type.clone(),
+                        descriptor.as_ref().clone(),
+                    ));
+                }
+                LinkOperation::Delete { link, referrer } => {
+                    if let Some(m) = metadata {
+                        link_cache.insert(link.clone(), m.clone());
+                        deletes.push((link.clone(), m.target.clone(), referrer.clone()));
+                    }
+                }
+            }
+        }
+
+        if creates.is_empty() && deletes.is_empty() {
+            guard.release().await;
+            return Ok(());
+        }
+
+        if !guard.is_valid() {
+            guard.release().await;
+            return Err(Error::Lock("lock invalidated during operation".into()));
+        }
+
+        let (pending_blob_ops, tracked_create_writes, non_tracked_create_writes) =
+            Self::build_create_ops(&creates, &mut link_cache);
+
+        join_all(
+            tracked_create_writes
+                .iter()
+                .chain(non_tracked_create_writes.iter())
+                .map(|(link, metadata)| async move {
+                    self.write_link_reference(namespace, link, metadata).await
+                }),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+        let (
+            pending_blob_ops,
+            tracked_delete_writes,
+            tracked_delete_removes,
+            non_tracked_delete_links,
+        ) = Self::build_delete_ops(&deletes, &mut link_cache, pending_blob_ops);
+
+        join_all(
+            tracked_delete_writes
+                .iter()
+                .map(|(link, metadata)| {
+                    let fut: Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> =
+                        Box::pin(self.write_link_reference(namespace, link, metadata));
+                    fut
+                })
+                .chain(
+                    tracked_delete_removes
+                        .iter()
+                        .chain(non_tracked_delete_links.iter())
+                        .map(|link| {
+                            let fut: Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> =
+                                Box::pin(self.delete_link_reference(namespace, link));
+                            fut
+                        }),
+                ),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+        for (link, metadata) in tracked_create_writes
+            .iter()
+            .chain(non_tracked_create_writes.iter())
+            .chain(tracked_delete_writes.iter())
+        {
+            self.cache_put(namespace, link, metadata).await;
+        }
+        for link in tracked_delete_removes
+            .iter()
+            .chain(non_tracked_delete_links.iter())
+        {
+            self.cache_invalidate(namespace, link).await;
+        }
+
+        // Release lock before CAS blob index updates — ETags handle concurrency.
+        guard.release().await;
+
+        join_all(
+            pending_blob_ops
+                .iter()
+                .map(|(digest, ops)| self.update_blob_index_cas(namespace, digest, ops)),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+        if !creates.is_empty()
+            && let Err(e) = self.register_namespace(namespace).await
+        {
+            warn!(namespace, error = %e, "Failed to register namespace");
+        }
+
+        Ok(())
+    }
+
+    /// Non-CAS write path: pre-lock reads to compute blob digest lock keys,
+    /// then validates under the lock with re-reads. Retries on concurrent
+    /// modification to ensure lock key coverage.
+    #[allow(clippy::too_many_lines)]
+    async fn update_links_locked(
+        &self,
+        namespace: &str,
+        operations: &[LinkOperation],
+    ) -> Result<(), Error> {
         let mut update_retries = MAX_UPDATE_RETRIES;
         loop {
             let mut link_cache: HashMap<LinkKind, LinkMetadata> = HashMap::new();
@@ -964,20 +1179,8 @@ impl MetadataStore for Backend {
             }))
             .await;
 
-            // When the S3 backend supports conditional writes, blob index updates use
-            // lock-free CAS (ETag-based compare-and-swap) and only link names are locked.
-            // Otherwise, `blob:{digest}` keys are included to serialize blob index
-            // read-modify-write cycles across concurrent callers.
-            let use_cas = self.supports_conditional_writes;
             let mut lock_keys: Vec<String> = Vec::new();
-            let mut creates: Vec<(
-                LinkKind,
-                Digest,
-                Option<Digest>,
-                Option<Digest>,
-                Option<String>,
-                Option<Descriptor>,
-            )> = Vec::new();
+            let mut creates: Vec<CreateOp> = Vec::new();
             let mut deletes: Vec<(LinkKind, Digest, Option<Digest>)> = Vec::new();
 
             for (_, create_data, delete_data) in prelock_results {
@@ -985,18 +1188,14 @@ impl MetadataStore for Backend {
                     create_data
                 {
                     lock_keys.push(format!("{namespace}:{link}"));
-                    if !use_cas {
-                        lock_keys.push(format!("blob:{target}"));
-                        if let Some(ref old) = old_target {
-                            lock_keys.push(format!("blob:{old}"));
-                        }
+                    lock_keys.push(format!("blob:{target}"));
+                    if let Some(ref old) = old_target {
+                        lock_keys.push(format!("blob:{old}"));
                     }
                     creates.push((link, target, old_target, referrer, media_type, descriptor));
                 } else if let Some((link, Some(meta), referrer)) = delete_data {
                     lock_keys.push(format!("{namespace}:{link}"));
-                    if !use_cas {
-                        lock_keys.push(format!("blob:{}", meta.target));
-                    }
+                    lock_keys.push(format!("blob:{}", meta.target));
                     deletes.push((link, meta.target, referrer));
                 }
             }
@@ -1078,54 +1277,9 @@ impl MetadataStore for Backend {
                 continue;
             }
 
-            let mut pending_blob_ops: HashMap<Digest, Vec<BlobIndexOperation>> = HashMap::new();
+            let (pending_blob_ops, tracked_create_writes, non_tracked_create_writes) =
+                Self::build_create_ops(&creates, &mut link_cache);
 
-            let mut tracked_create_writes: Vec<(LinkKind, LinkMetadata)> = Vec::new();
-            let mut non_tracked_create_writes: Vec<(LinkKind, LinkMetadata)> = Vec::new();
-            for (link, target, old_target, referrer, media_type, descriptor) in &creates {
-                let is_tracked = is_tracked_link(link);
-
-                if is_tracked && referrer.is_some() {
-                    let mut metadata = link_cache.remove(link).unwrap_or_else(|| {
-                        LinkMetadata::from_digest(target.clone())
-                            .with_media_type(media_type.clone())
-                            .with_descriptor((*descriptor).clone())
-                    });
-
-                    if let Some(manifest_digest) = referrer {
-                        metadata.add_referrer(manifest_digest.clone());
-                    }
-
-                    if old_target.is_none() {
-                        pending_blob_ops
-                            .entry(target.clone())
-                            .or_default()
-                            .push(BlobIndexOperation::Insert(link.clone()));
-                    }
-
-                    tracked_create_writes.push((link.clone(), metadata));
-                } else {
-                    pending_blob_ops
-                        .entry(target.clone())
-                        .or_default()
-                        .push(BlobIndexOperation::Insert(link.clone()));
-                    if let Some(old) = old_target
-                        && *old != *target
-                    {
-                        pending_blob_ops
-                            .entry(old.clone())
-                            .or_default()
-                            .push(BlobIndexOperation::Remove(link.clone()));
-                    }
-
-                    non_tracked_create_writes.push((
-                        link.clone(),
-                        LinkMetadata::from_digest(target.clone())
-                            .with_media_type(media_type.clone())
-                            .with_descriptor((*descriptor).clone()),
-                    ));
-                }
-            }
             if !guard.is_valid() {
                 guard.release().await;
                 return Err(Error::Lock("lock invalidated during operation".into()));
@@ -1143,36 +1297,13 @@ impl MetadataStore for Backend {
             .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
 
-            let mut tracked_delete_writes: Vec<(LinkKind, LinkMetadata)> = Vec::new();
-            let mut tracked_delete_removes: Vec<LinkKind> = Vec::new();
-            let mut non_tracked_delete_links: Vec<LinkKind> = Vec::new();
-            for (link, target, referrer) in &valid_deletes {
-                let is_tracked = is_tracked_link(link);
+            let (
+                pending_blob_ops,
+                tracked_delete_writes,
+                tracked_delete_removes,
+                non_tracked_delete_links,
+            ) = Self::build_delete_ops(&valid_deletes, &mut link_cache, pending_blob_ops);
 
-                if is_tracked && referrer.is_some() {
-                    if let Some(mut metadata) = link_cache.remove(link) {
-                        if let Some(manifest_digest) = referrer {
-                            metadata.remove_referrer(manifest_digest);
-                        }
-
-                        if metadata.has_references() {
-                            tracked_delete_writes.push((link.clone(), metadata));
-                        } else {
-                            tracked_delete_removes.push(link.clone());
-                            pending_blob_ops
-                                .entry(target.clone())
-                                .or_default()
-                                .push(BlobIndexOperation::Remove(link.clone()));
-                        }
-                    }
-                } else {
-                    non_tracked_delete_links.push(link.clone());
-                    pending_blob_ops
-                        .entry(target.clone())
-                        .or_default()
-                        .push(BlobIndexOperation::Remove(link.clone()));
-                }
-            }
             if !guard.is_valid() {
                 guard.release().await;
                 return Err(Error::Lock("lock invalidated during operation".into()));
@@ -1210,49 +1341,34 @@ impl MetadataStore for Backend {
             for (link, metadata) in tracked_create_writes
                 .iter()
                 .chain(non_tracked_create_writes.iter())
+                .chain(tracked_delete_writes.iter())
             {
                 self.cache_put(namespace, link, metadata).await;
             }
-            for (link, _, _) in &valid_deletes {
+            for link in tracked_delete_removes
+                .iter()
+                .chain(non_tracked_delete_links.iter())
+            {
                 self.cache_invalidate(namespace, link).await;
             }
 
-            if use_cas {
-                // Release the lock before blob index updates — CAS handles
-                // concurrency via ETags without requiring lock coordination.
+            // Blob index shard updates run under the lock (blob:{digest} keys
+            // are included in lock_keys above).
+            join_all(
+                pending_blob_ops
+                    .iter()
+                    .map(|(digest, ops)| self.update_blob_index_shard(namespace, digest, ops)),
+            )
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+            if !guard.is_valid() {
                 guard.release().await;
-
-                // Blob index updates use optimistic concurrency (CAS via ETags) and
-                // run outside the lock. Each digest has its own S3 key, so updates to
-                // different digests are independent and can run in parallel. Concurrent
-                // updates from other callers are resolved by CAS retry.
-                join_all(
-                    pending_blob_ops
-                        .iter()
-                        .map(|(digest, ops)| self.update_blob_index_cas(namespace, digest, ops)),
-                )
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()?;
-            } else {
-                // Without conditional write support, blob index shard updates run
-                // under the lock (blob:{digest} keys are included in lock_keys above).
-                join_all(
-                    pending_blob_ops
-                        .iter()
-                        .map(|(digest, ops)| self.update_blob_index_shard(namespace, digest, ops)),
-                )
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()?;
-
-                if !guard.is_valid() {
-                    guard.release().await;
-                    return Err(Error::Lock("lock invalidated during operation".into()));
-                }
-
-                guard.release().await;
+                return Err(Error::Lock("lock invalidated during operation".into()));
             }
+
+            guard.release().await;
 
             if !creates.is_empty()
                 && let Err(e) = self.register_namespace(namespace).await
@@ -1264,19 +1380,113 @@ impl MetadataStore for Backend {
         }
     }
 
-    async fn flush_access_times(&self) {
-        Backend::flush_access_times(self).await;
+    /// Builds blob index operations and link writes for create operations.
+    fn build_create_ops(
+        creates: &[CreateOp],
+        link_cache: &mut HashMap<LinkKind, LinkMetadata>,
+    ) -> CreateOpsResult {
+        let mut pending_blob_ops: HashMap<Digest, Vec<BlobIndexOperation>> = HashMap::new();
+        let mut tracked_create_writes: Vec<(LinkKind, LinkMetadata)> = Vec::new();
+        let mut non_tracked_create_writes: Vec<(LinkKind, LinkMetadata)> = Vec::new();
+
+        for (link, target, old_target, referrer, media_type, descriptor) in creates {
+            let is_tracked = is_tracked_link(link);
+
+            if is_tracked && referrer.is_some() {
+                let mut metadata = link_cache.remove(link).unwrap_or_else(|| {
+                    LinkMetadata::from_digest(target.clone())
+                        .with_media_type(media_type.clone())
+                        .with_descriptor(descriptor.clone())
+                });
+
+                if let Some(manifest_digest) = referrer {
+                    metadata.add_referrer(manifest_digest.clone());
+                }
+
+                if old_target.is_none() {
+                    pending_blob_ops
+                        .entry(target.clone())
+                        .or_default()
+                        .push(BlobIndexOperation::Insert(link.clone()));
+                }
+
+                tracked_create_writes.push((link.clone(), metadata));
+            } else {
+                pending_blob_ops
+                    .entry(target.clone())
+                    .or_default()
+                    .push(BlobIndexOperation::Insert(link.clone()));
+                if let Some(old) = old_target
+                    && *old != *target
+                {
+                    pending_blob_ops
+                        .entry(old.clone())
+                        .or_default()
+                        .push(BlobIndexOperation::Remove(link.clone()));
+                }
+
+                non_tracked_create_writes.push((
+                    link.clone(),
+                    LinkMetadata::from_digest(target.clone())
+                        .with_media_type(media_type.clone())
+                        .with_descriptor(descriptor.clone()),
+                ));
+            }
+        }
+
+        (
+            pending_blob_ops,
+            tracked_create_writes,
+            non_tracked_create_writes,
+        )
     }
-}
 
-fn is_tracked_link(link: &LinkKind) -> bool {
-    matches!(
-        link,
-        LinkKind::Layer(_) | LinkKind::Config(_) | LinkKind::Manifest(_, _)
-    )
-}
+    /// Builds blob index operations and link writes/deletes for delete operations.
+    fn build_delete_ops(
+        deletes: &[(LinkKind, Digest, Option<Digest>)],
+        link_cache: &mut HashMap<LinkKind, LinkMetadata>,
+        mut pending_blob_ops: HashMap<Digest, Vec<BlobIndexOperation>>,
+    ) -> DeleteOpsResult {
+        let mut tracked_delete_writes: Vec<(LinkKind, LinkMetadata)> = Vec::new();
+        let mut tracked_delete_removes: Vec<LinkKind> = Vec::new();
+        let mut non_tracked_delete_links: Vec<LinkKind> = Vec::new();
 
-impl Backend {
+        for (link, target, referrer) in deletes {
+            let is_tracked = is_tracked_link(link);
+
+            if is_tracked && referrer.is_some() {
+                if let Some(mut metadata) = link_cache.remove(link) {
+                    if let Some(manifest_digest) = referrer {
+                        metadata.remove_referrer(manifest_digest);
+                    }
+
+                    if metadata.has_references() {
+                        tracked_delete_writes.push((link.clone(), metadata));
+                    } else {
+                        tracked_delete_removes.push(link.clone());
+                        pending_blob_ops
+                            .entry(target.clone())
+                            .or_default()
+                            .push(BlobIndexOperation::Remove(link.clone()));
+                    }
+                }
+            } else {
+                non_tracked_delete_links.push(link.clone());
+                pending_blob_ops
+                    .entry(target.clone())
+                    .or_default()
+                    .push(BlobIndexOperation::Remove(link.clone()));
+            }
+        }
+
+        (
+            pending_blob_ops,
+            tracked_delete_writes,
+            tracked_delete_removes,
+            non_tracked_delete_links,
+        )
+    }
+
     /// Unconditional read-modify-write on a namespace shard (caller must hold lock).
     async fn update_blob_index_shard(
         &self,

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -780,6 +780,9 @@ impl MetadataStore for Backend {
             }))
             .await;
 
+            // Lock keys include both link names and `blob:{digest}` for every target digest.
+            // This ensures blob index updates (which perform read-modify-write on per-digest
+            // index files) are serialized across concurrent update_links calls.
             let mut lock_keys: Vec<String> = Vec::new();
             let mut creates: Vec<(
                 LinkKind,
@@ -1018,6 +1021,10 @@ impl MetadataStore for Backend {
                 return Err(Error::Lock("lock invalidated during operation".into()));
             }
 
+            // SAFETY: Blob index updates for different digests are independent (each digest
+            // has its own S3 key). Updates for the same digest within this call are grouped
+            // by the pending_blob_ops HashMap. Cross-call updates to the same digest are
+            // serialized by the `blob:{digest}` lock key acquired above.
             join_all(pending_blob_ops.iter().map(|(digest, ops)| async move {
                 let path = path_builder::blob_index_path(digest);
                 let mut blob_index = match self.store.read(&path).await {

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -27,8 +27,8 @@ use crate::{
     registry::{
         data_store,
         metadata_store::{
-            BlobIndex, BlobIndexOperation, Error, LinkMetadata, LinkOperation, LockConfig,
-            LockStrategy, MetadataStore,
+            BlobIndex, BlobIndexOperation, ConditionalCapabilities, Error, LinkMetadata,
+            LinkOperation, LockConfig, LockStrategy, MetadataStore,
             link_kind::LinkKind,
             lock::{self, LockBackend, MemoryBackend},
         },
@@ -72,6 +72,20 @@ pub struct BackendConfig {
     pub lock_strategy: LockStrategy,
     pub link_cache_ttl: u64,
     pub access_time_debounce_secs: u64,
+    /// Explicitly declare which conditional S3 operations the provider supports.
+    /// Each boolean flag corresponds to a distinct HTTP conditional header:
+    /// - `put_if_none_match`: PutObject with If-None-Match: * (create-only)
+    /// - `put_if_match`: PutObject with If-Match: <etag> (update-only, enables CAS optimizations)
+    /// - `delete_if_match`: DeleteObject with If-Match: <etag> (atomic lock release)
+    ///
+    /// When set, the startup probe is skipped entirely and your declared values are used.
+    /// When absent, the probe runs automatically if `lock_strategy = "s3"` to auto-detect
+    /// capabilities (and capabilities default to all-false for other lock strategies).
+    ///
+    /// Set explicitly to avoid startup latency from probing, or to handle S3-compatible
+    /// providers where probe results may be inaccurate. Both `put_if_none_match` and
+    /// `put_if_match` must be true for compare-and-swap (CAS) operations to be used.
+    pub capabilities: Option<ConditionalCapabilities>,
 }
 
 impl Default for BackendConfig {
@@ -86,6 +100,7 @@ impl Default for BackendConfig {
             lock_strategy: LockStrategy::Memory,
             link_cache_ttl: default_link_cache_ttl(),
             access_time_debounce_secs: default_access_time_debounce(),
+            capabilities: None,
         }
     }
 }
@@ -112,6 +127,8 @@ impl<'de> Deserialize<'de> for BackendConfig {
             link_cache_ttl: u64,
             #[serde(default = "default_access_time_debounce")]
             access_time_debounce_secs: u64,
+            #[serde(default)]
+            capabilities: Option<ConditionalCapabilities>,
         }
 
         let raw = Raw::deserialize(deserializer)?;
@@ -128,6 +145,7 @@ impl<'de> Deserialize<'de> for BackendConfig {
             lock_strategy,
             link_cache_ttl: raw.link_cache_ttl,
             access_time_debounce_secs: raw.access_time_debounce_secs,
+            capabilities: raw.capabilities,
         })
     }
 }
@@ -202,6 +220,10 @@ impl AccessTimeWriter {
     }
 
     async fn flush_one(backend: &Backend, namespace: &str, link: &LinkKind) -> Result<(), Error> {
+        if backend.conditional.put_if_match {
+            backend.update_access_time_cas(namespace, link).await?;
+            return Ok(());
+        }
         let guard = backend
             .lock
             .acquire(&[format!("{namespace}:{link}")])
@@ -245,10 +267,10 @@ pub struct Backend {
     cache: Option<Arc<dyn Cache>>,
     link_cache_ttl: u64,
     access_time_writer: Option<AccessTimeWriter>,
-    /// Whether the S3 backend supports conditional writes (If-Match / If-None-Match).
-    /// When true, blob index updates use lock-free CAS. When false, they are protected
-    /// by the distributed lock alongside link updates.
-    supports_conditional_writes: bool,
+    /// Per-operation conditional capabilities probed at startup.
+    /// Controls whether CAS paths are used for blob index, link updates, namespace
+    /// registry writes, and access-time updates.
+    conditional: ConditionalCapabilities,
     known_namespaces: Arc<Mutex<HashSet<String>>>,
     // Held for Drop side-effect: signals the flush task to exit when the last Backend is dropped.
     #[allow(dead_code)]
@@ -257,11 +279,33 @@ pub struct Backend {
 
 const MAX_UPDATE_RETRIES: u32 = 10;
 const MAX_BLOB_INDEX_CAS_RETRIES: u32 = 20;
+const MAX_ACCESS_TIME_CAS_RETRIES: u32 = 3;
 
 impl Backend {
-    pub fn new(config: &BackendConfig) -> Result<Self, Error> {
+    /// Create a new S3 metadata-store backend.
+    ///
+    /// `conditional` overrides the capabilities used for lock backend construction and CAS
+    /// write paths. Pass `None` to use defaults (all capabilities assumed present for S3 lock
+    /// strategy, none for other strategies). Pass `Some(caps)` with the result of
+    /// `probe_conditional_capabilities` to use the actual probed values.
+    pub fn new(
+        config: &BackendConfig,
+        conditional: Option<ConditionalCapabilities>,
+    ) -> Result<Self, Error> {
         info!("Using S3 metadata-store backend");
         let store = data_store::s3::Backend::new(&config.to_data_store_config())?;
+
+        let conditional = conditional.unwrap_or_else(|| {
+            if matches!(config.lock_strategy, LockStrategy::S3(_)) {
+                ConditionalCapabilities {
+                    put_if_none_match: true,
+                    put_if_match: true,
+                    delete_if_match: true,
+                }
+            } else {
+                ConditionalCapabilities::default()
+            }
+        });
 
         let lock: Arc<dyn LockBackend + Send + Sync> = match &config.lock_strategy {
             LockStrategy::Redis(redis_config) => {
@@ -280,9 +324,12 @@ impl Backend {
                         })?,
                 );
                 Arc::new(
-                    lock::S3LockBackend::new(lock_store, s3_lock_config).map_err(|e| {
-                        Error::Lock(format!("Failed to initialize S3 lock store: {e}"))
-                    })?,
+                    lock::S3LockBackend::new(
+                        lock_store,
+                        s3_lock_config,
+                        conditional.delete_if_match,
+                    )
+                    .map_err(|e| Error::Lock(format!("Failed to initialize S3 lock store: {e}")))?,
                 )
             }
             LockStrategy::Memory => {
@@ -291,18 +338,13 @@ impl Backend {
             }
         };
 
-        // S3 lock strategy probes conditional write support at startup, so if
-        // we're using S3 locks we know conditionals work. For other lock strategies
-        // the S3 backend may not support them (e.g. older S3-compatible stores).
-        let supports_conditional_writes = matches!(config.lock_strategy, LockStrategy::S3(_));
-
         if config.access_time_debounce_secs == 0
             && matches!(config.lock_strategy, LockStrategy::S3(_))
         {
             warn!(
                 "access_time_debounce_secs is 0 with S3 lock strategy; \
-                 every manifest pull will acquire an S3 lock for access time updates, \
-                 which adds significant latency and S3 API cost at scale. \
+                 every manifest pull will trigger a synchronous access time update \
+                 (CAS loop, with lock fallback), adding S3 API latency. \
                  Consider setting access_time_debounce_secs to 60 or higher."
             );
         }
@@ -324,7 +366,7 @@ impl Backend {
                 cache: None,
                 link_cache_ttl: config.link_cache_ttl,
                 access_time_writer: access_time_writer.clone(),
-                supports_conditional_writes,
+                conditional: conditional.clone(),
                 known_namespaces: Arc::new(Mutex::new(HashSet::new())),
                 flush_handle: None,
             };
@@ -351,7 +393,7 @@ impl Backend {
             cache: None,
             link_cache_ttl: config.link_cache_ttl,
             access_time_writer,
-            supports_conditional_writes,
+            conditional,
             known_namespaces: Arc::new(Mutex::new(HashSet::new())),
             flush_handle,
         };
@@ -359,98 +401,111 @@ impl Backend {
         Ok(backend)
     }
 
-    pub async fn probe_conditional_write_support(
+    /// Probe each conditional S3 operation independently.
+    ///
+    /// Tests `PutObject If-None-Match: *`, `PutObject If-Match: <etag>`, and
+    /// `DeleteObject If-Match: <etag>` in sequence. Each probe is self-validating:
+    /// bogus-ETag attempts verify that the provider actually enforces the condition.
+    ///
+    /// Returns the probed capabilities. The caller is responsible for failing startup
+    /// if any required capability is absent.
+    pub async fn probe_conditional_capabilities(
         store: &data_store::s3::Backend,
-    ) -> Result<(), Error> {
+    ) -> Result<ConditionalCapabilities, Error> {
         let probe_key = format!("_angos_probe_{}", uuid::Uuid::new_v4());
         let content: &[u8] = b"probe";
 
-        // Step 1: PUT the probe object
-        if let Err(e) = store.put_object(&probe_key, content).await {
-            let _ = store.delete(&probe_key).await;
-            return Err(Error::Lock(format!(
-                "S3 conditional write probe failed to create probe object: {e}"
-            )));
-        }
+        store.put_object(&probe_key, content).await.map_err(|e| {
+            Error::Lock(format!(
+                "conditional capability probe: failed to create probe object: {e}"
+            ))
+        })?;
 
-        // Step 2: PUT again with If-None-Match: * — expect 412 PreconditionFailed
-        let if_none_match_result = store.put_object_if_not_exists(&probe_key, content).await;
-
-        // Step 3: Test If-Match — read current ETag, update should succeed
-        let if_match_result = match store.read_with_etag(&probe_key).await {
-            Ok((_, Some(etag))) => {
-                let update_result = store
-                    .put_object_if_match(&probe_key, &etag, b"updated".to_vec())
-                    .await;
-                let bogus_result = store
-                    .put_object_if_match(&probe_key, "\"bogus\"", b"fail".to_vec())
-                    .await;
-                Some((update_result, bogus_result))
-            }
-            Ok((_, None)) => {
-                let _ = store.delete(&probe_key).await;
-                return Err(Error::Lock(
-                    "S3 conditional write probe: ETag not returned, \
-                     If-Match support cannot be verified"
-                        .to_string(),
-                ));
+        // Test If-None-Match: * — expect 412 because the object already exists.
+        let put_if_none_match = match store.put_object_if_not_exists(&probe_key, content).await {
+            Err(data_store::Error::PreconditionFailed) => true,
+            Ok(_) => {
+                warn!(
+                    "conditional probe: If-None-Match: * was accepted on existing key; provider does not enforce it"
+                );
+                false
             }
             Err(e) => {
-                let _ = store.delete(&probe_key).await;
-                return Err(Error::Lock(format!(
-                    "S3 conditional write probe failed to read probe object for If-Match test: {e}"
-                )));
+                warn!("conditional probe: If-None-Match error: {e}");
+                false
             }
         };
 
-        // Step 4: Clean up probe object regardless of outcome
-        let _ = store.delete(&probe_key).await;
-
-        // Step 5: Evaluate If-None-Match result
-        match if_none_match_result {
-            Err(data_store::Error::PreconditionFailed) => {}
-            Ok(_) => {
-                return Err(Error::Lock(
-                    "S3 backend does not support If-None-Match: * conditional writes, \
-                     required for lock_strategy = s3. Use lock_strategy = redis or \
-                     lock_strategy = memory instead."
-                        .to_string(),
-                ));
+        // Test If-Match: <etag> — correct ETag must succeed; bogus ETag must fail.
+        let put_if_match = match store.read_with_etag(&probe_key).await {
+            Ok((_, Some(etag))) => {
+                let correct = store
+                    .put_object_if_match(&probe_key, &etag, b"updated".to_vec())
+                    .await
+                    .is_ok();
+                let bogus_rejected = matches!(
+                    store
+                        .put_object_if_match(&probe_key, "\"bogus\"", b"fail".to_vec())
+                        .await,
+                    Err(data_store::Error::PreconditionFailed)
+                );
+                correct && bogus_rejected
+            }
+            Ok((_, None)) => {
+                warn!("conditional probe: ETag not returned; If-Match support cannot be verified");
+                false
             }
             Err(e) => {
-                return Err(Error::Lock(format!(
-                    "S3 conditional write probe (If-None-Match) failed: {e}"
-                )));
+                warn!("conditional probe: failed to read probe object for If-Match test: {e}");
+                false
             }
-        }
+        };
 
-        // Step 6: Evaluate If-Match results
-        if let Some((update_result, bogus_result)) = if_match_result {
-            if let Err(e) = update_result {
-                return Err(Error::Lock(format!(
-                    "S3 backend does not support If-Match conditional writes (update failed): {e}"
-                )));
+        // Test DeleteObject If-Match: <etag> — bogus ETag must fail; correct ETag must succeed.
+        // Re-read the current ETag after the put_if_match update may have changed it.
+        let delete_if_match = match store.read_with_etag(&probe_key).await {
+            Ok((_, Some(etag))) => {
+                // Bogus-ETag attempt first: if the provider ignores the condition and deletes
+                // the object, the correct-ETag attempt below will hit NotFound and correct=false.
+                let bogus_rejected = matches!(
+                    store.delete_if_match(&probe_key, "\"bogus\"").await,
+                    Err(data_store::Error::PreconditionFailed)
+                );
+                let correct = store.delete_if_match(&probe_key, &etag).await.is_ok();
+                bogus_rejected && correct
             }
-            match bogus_result {
-                Err(data_store::Error::PreconditionFailed) => {}
-                Ok(_) => {
-                    return Err(Error::Lock(
-                        "S3 backend does not enforce If-Match: bogus ETag was accepted, \
-                         required for lock heartbeat. Use lock_strategy = redis or \
-                         lock_strategy = memory instead."
-                            .to_string(),
-                    ));
-                }
-                Err(e) => {
-                    return Err(Error::Lock(format!(
-                        "S3 conditional write probe (If-Match bogus) failed unexpectedly: {e}"
-                    )));
-                }
+            Ok((_, None)) => {
+                warn!(
+                    "conditional probe: ETag not returned; DeleteObject If-Match support cannot be verified"
+                );
+                false
             }
-        }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+            Err(e) => {
+                warn!(
+                    "conditional probe: failed to read probe object for delete_if_match test: {e}"
+                );
+                false
+            }
+        };
 
-        info!("S3 conditional write probe passed (If-None-Match and If-Match supported)");
-        Ok(())
+        // Cleanup — may already have been deleted by the delete_if_match test.
+        let _ = store.delete(&probe_key).await;
+
+        let capabilities = ConditionalCapabilities {
+            put_if_none_match,
+            put_if_match,
+            delete_if_match,
+        };
+
+        info!(
+            if_none_match = capabilities.put_if_none_match,
+            if_match = capabilities.put_if_match,
+            delete_if_match = capabilities.delete_if_match,
+            "S3 conditional capability probe complete"
+        );
+
+        Ok(capabilities)
     }
 
     pub async fn flush_access_times(&self) {
@@ -590,6 +645,10 @@ impl Backend {
 
 #[async_trait]
 impl MetadataStore for Backend {
+    fn conditional_capabilities(&self) -> Option<ConditionalCapabilities> {
+        Some(self.conditional.clone())
+    }
+
     #[instrument(skip(self))]
     async fn list_namespaces(
         &self,
@@ -888,7 +947,7 @@ impl MetadataStore for Backend {
         digest: &Digest,
         operation: BlobIndexOperation,
     ) -> Result<(), Error> {
-        if self.supports_conditional_writes {
+        if self.conditional.supports_cas() {
             return self
                 .update_blob_index_cas(namespace, digest, &[operation])
                 .await;
@@ -915,6 +974,10 @@ impl MetadataStore for Backend {
                     data
                 };
                 writer.record(namespace, link).await;
+                Ok(link_data)
+            } else if self.conditional.put_if_match {
+                let link_data = self.update_access_time_cas(namespace, link).await?;
+                self.cache_put(namespace, link, &link_data).await;
                 Ok(link_data)
             } else {
                 let guard = self.lock.acquire(&[format!("{namespace}:{link}")]).await?;
@@ -950,7 +1013,7 @@ impl MetadataStore for Backend {
             return Ok(());
         }
 
-        if self.supports_conditional_writes {
+        if self.conditional.supports_cas() {
             self.update_links_cas(namespace, operations).await
         } else {
             self.update_links_locked(namespace, operations).await
@@ -1708,7 +1771,7 @@ impl Backend {
                 path_builder::namespace_registry_shard_dir()
             );
 
-            if self.supports_conditional_writes {
+            if self.conditional.supports_cas() {
                 let etag = match self.store.read_with_etag(&path).await {
                     Ok((_, etag)) => etag,
                     Err(e) if e.kind() == ErrorKind::NotFound => None,
@@ -1751,7 +1814,7 @@ impl Backend {
             return Ok(());
         }
 
-        if self.supports_conditional_writes {
+        if self.conditional.supports_cas() {
             self.register_namespace_cas(namespace).await
         } else {
             self.register_namespace_unconditional(namespace).await
@@ -1896,6 +1959,49 @@ impl Backend {
         Ok(())
     }
 
+    async fn update_access_time_cas(
+        &self,
+        namespace: &str,
+        link: &LinkKind,
+    ) -> Result<LinkMetadata, Error> {
+        let link_path = path_builder::link_path(link, namespace);
+
+        for _ in 0..MAX_ACCESS_TIME_CAS_RETRIES {
+            let (data, etag) = match self.store.read_with_etag(&link_path).await {
+                Ok((data, etag)) => (data, etag),
+                Err(e) if e.kind() == ErrorKind::NotFound => return Err(Error::ReferenceNotFound),
+                Err(e) => return Err(e.into()),
+            };
+            let link_data = LinkMetadata::from_bytes(data)?.accessed();
+            let Some(etag) = etag else {
+                break;
+            };
+            let serialized = Bytes::from(serde_json::to_vec(&link_data)?);
+            match self
+                .store
+                .put_object_if_match(&link_path, &etag, serialized)
+                .await
+            {
+                Ok(_) => return Ok(link_data),
+                Err(data_store::Error::PreconditionFailed) => continue,
+                Err(e) => return Err(Error::StorageBackend(e.to_string())),
+            }
+        }
+
+        // CAS exhausted or no ETag — fall back to lock-protected path
+        let guard = self.lock.acquire(&[format!("{namespace}:{link}")]).await?;
+        let link_data = self.read_link_reference(namespace, link).await?.accessed();
+        if !guard.is_valid() {
+            return Err(Error::Lock(
+                "lock invalidated during access time update".into(),
+            ));
+        }
+        self.write_link_reference(namespace, link, &link_data)
+            .await?;
+        guard.release().await;
+        Ok(link_data)
+    }
+
     async fn read_link_reference(
         &self,
         namespace: &str,
@@ -1974,12 +2080,15 @@ mod tests {
             lock_strategy: LockStrategy::Memory,
             link_cache_ttl: 30,
             access_time_debounce_secs: 0,
+            capabilities: None,
         }
     }
 
     fn test_backend_with_cache(config: &BackendConfig) -> (Backend, Arc<dyn cache::Cache>) {
         let cache: Arc<dyn cache::Cache> = Arc::new(cache::memory::Backend::new());
-        let backend = Backend::new(config).unwrap().with_cache(cache.clone());
+        let backend = Backend::new(config, None)
+            .unwrap()
+            .with_cache(cache.clone());
         (backend, cache)
     }
 
@@ -2334,7 +2443,7 @@ mod tests {
     fn test_backend_with_debounce(config: &BackendConfig, debounce_secs: u64) -> Backend {
         let mut cfg = config.clone();
         cfg.access_time_debounce_secs = debounce_secs;
-        Backend::new(&cfg).unwrap()
+        Backend::new(&cfg, None).unwrap()
     }
 
     #[tokio::test]
@@ -2733,7 +2842,7 @@ mod tests {
     #[tokio::test]
     async fn test_blob_index_updates_multiple_digests() {
         let config = test_config();
-        let backend = Backend::new(&config).unwrap();
+        let backend = Backend::new(&config, None).unwrap();
         let namespace = "blob-index-multi-digest-test";
 
         let digests: Vec<Digest> = (0..5)
@@ -2773,7 +2882,7 @@ mod tests {
     #[tokio::test]
     async fn test_tracked_link_creates_with_referrers() {
         let config = test_config();
-        let backend = Backend::new(&config).unwrap();
+        let backend = Backend::new(&config, None).unwrap();
         let namespace = "tracked-creates-referrer-test";
 
         let referrer_digest = Digest::from_str(
@@ -2841,7 +2950,7 @@ mod tests {
     #[tokio::test]
     async fn test_tracked_link_deletes_with_referrers() {
         let config = test_config();
-        let backend = Backend::new(&config).unwrap();
+        let backend = Backend::new(&config, None).unwrap();
         let namespace = "tracked-deletes-referrer-test";
 
         let referrer_digest = Digest::from_str(
@@ -2908,7 +3017,7 @@ mod tests {
     #[tokio::test]
     async fn test_mixed_creates_and_deletes_across_digests() {
         let config = test_config();
-        let backend = Backend::new(&config).unwrap();
+        let backend = Backend::new(&config, None).unwrap();
         let namespace = "mixed-ops-across-digests-test";
 
         let digest_keep = Digest::from_str(
@@ -3003,7 +3112,7 @@ mod tests {
         let mut cfg = config.clone();
         cfg.access_time_debounce_secs = 60;
         let cache: Arc<dyn cache::Cache> = Arc::new(cache::memory::Backend::new());
-        let backend = Backend::new(&cfg).unwrap().with_cache(cache.clone());
+        let backend = Backend::new(&cfg, None).unwrap().with_cache(cache.clone());
         let namespace = "cache-debounce-hit-ns";
         let digest = Digest::from_str(
             "sha256:db01a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6",
@@ -3043,7 +3152,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_probe_conditional_write_support() {
+    async fn test_probe_conditional_capabilities() {
         let config = test_config();
         let store = data_store::s3::Backend::new(&data_store::s3::BackendConfig {
             access_key_id: config.access_key_id.clone(),
@@ -3056,10 +3165,16 @@ mod tests {
         })
         .unwrap();
 
-        let result = Backend::probe_conditional_write_support(&store).await;
+        let result = Backend::probe_conditional_capabilities(&store).await;
+        assert!(result.is_ok(), "Probe should pass on MinIO: {result:?}");
+        let caps = result.unwrap();
+        assert!(caps.put_if_none_match, "MinIO should support If-None-Match");
+        assert!(caps.put_if_match, "MinIO should support If-Match");
+        // MinIO does not enforce If-Match on DeleteObject (returns 200 regardless of ETag),
+        // so delete_if_match is expected to be false.
         assert!(
-            result.is_ok(),
-            "Probe should pass on MinIO (supports If-None-Match): {result:?}"
+            !caps.delete_if_match,
+            "MinIO does not support conditional delete (ignores If-Match on DeleteObject)"
         );
     }
 }

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -104,16 +104,28 @@ fn default_access_time_debounce() -> u64 {
     60
 }
 
-impl From<BackendConfig> for data_store::s3::BackendConfig {
-    fn from(config: BackendConfig) -> Self {
-        Self {
-            access_key_id: config.access_key_id,
-            secret_key: config.secret_key,
-            endpoint: config.endpoint,
-            bucket: config.bucket,
-            region: config.region,
-            key_prefix: config.key_prefix,
+impl BackendConfig {
+    pub fn to_data_store_config(&self) -> data_store::s3::BackendConfig {
+        data_store::s3::BackendConfig {
+            access_key_id: self.access_key_id.clone(),
+            secret_key: self.secret_key.clone(),
+            endpoint: self.endpoint.clone(),
+            bucket: self.bucket.clone(),
+            region: self.region.clone(),
+            key_prefix: self.key_prefix.clone(),
             ..Default::default()
+        }
+    }
+
+    pub fn to_lock_store_config(
+        &self,
+        lock_config: &lock::s3::S3LockConfig,
+    ) -> data_store::s3::BackendConfig {
+        data_store::s3::BackendConfig {
+            operation_timeout_secs: lock_config.operation_timeout_secs,
+            operation_attempt_timeout_secs: lock_config.operation_attempt_timeout_secs,
+            max_attempts: lock_config.max_attempts,
+            ..self.to_data_store_config()
         }
     }
 }
@@ -179,15 +191,7 @@ pub struct Backend {
 impl Backend {
     pub fn new(config: &BackendConfig) -> Result<Self, Error> {
         info!("Using S3 metadata-store backend");
-        let store = data_store::s3::Backend::new(&data_store::s3::BackendConfig {
-            access_key_id: config.access_key_id.clone(),
-            secret_key: config.secret_key.clone(),
-            endpoint: config.endpoint.clone(),
-            bucket: config.bucket.clone(),
-            region: config.region.clone(),
-            key_prefix: config.key_prefix.clone(),
-            ..Default::default()
-        })?;
+        let store = data_store::s3::Backend::new(&config.to_data_store_config())?;
 
         let lock: Arc<dyn LockBackend + Send + Sync> = match &config.lock_strategy {
             LockStrategy::Redis(redis_config) => {
@@ -199,7 +203,12 @@ impl Backend {
             }
             LockStrategy::S3(s3_lock_config) => {
                 info!("Using S3 lock store for S3 metadata-store");
-                let lock_store = Arc::new(store.clone());
+                let lock_store = Arc::new(
+                    data_store::s3::Backend::new(&config.to_lock_store_config(s3_lock_config))
+                        .map_err(|e| {
+                            Error::Lock(format!("Failed to initialize S3 lock store: {e}"))
+                        })?,
+                );
                 Arc::new(
                     lock::S3LockBackend::new(lock_store, s3_lock_config).map_err(|e| {
                         Error::Lock(format!("Failed to initialize S3 lock store: {e}"))

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -243,6 +243,17 @@ impl Backend {
             }
         };
 
+        if config.access_time_debounce_secs == 0
+            && matches!(config.lock_strategy, LockStrategy::S3(_))
+        {
+            warn!(
+                "access_time_debounce_secs is 0 with S3 lock strategy; \
+                 every manifest pull will acquire an S3 lock for access time updates, \
+                 which adds significant latency and S3 API cost at scale. \
+                 Consider setting access_time_debounce_secs to 60 or higher."
+            );
+        }
+
         let access_time_writer = if config.access_time_debounce_secs > 0 {
             Some(AccessTimeWriter::new())
         } else {

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -1025,13 +1025,6 @@ impl MetadataStore for Backend {
     }
 }
 
-fn is_tracked_link(link: &LinkKind) -> bool {
-    matches!(
-        link,
-        LinkKind::Layer(_) | LinkKind::Config(_) | LinkKind::Manifest(_, _)
-    )
-}
-
 impl Backend {
     /// CAS-optimized write path with lock-free fast path for new links.
     ///
@@ -1069,7 +1062,7 @@ impl Backend {
                     referrer,
                     media_type,
                     descriptor,
-                } if !is_tracked_link(link) || referrer.is_none() => {
+                } if !link.is_tracked() || referrer.is_none() => {
                     any_creates = true;
                     let metadata = LinkMetadata::from_digest(target.clone())
                         .with_media_type(media_type.clone())
@@ -1545,7 +1538,7 @@ impl Backend {
         let mut non_tracked_create_writes: Vec<(LinkKind, LinkMetadata)> = Vec::new();
 
         for (link, target, old_target, referrer, media_type, descriptor) in creates {
-            let is_tracked = is_tracked_link(link);
+            let is_tracked = link.is_tracked();
 
             if is_tracked && referrer.is_some() {
                 let mut metadata = link_cache.remove(link).unwrap_or_else(|| {
@@ -1607,7 +1600,7 @@ impl Backend {
         let mut non_tracked_delete_links: Vec<LinkKind> = Vec::new();
 
         for (link, target, referrer) in deletes {
-            let is_tracked = is_tracked_link(link);
+            let is_tracked = link.is_tracked();
 
             if is_tracked && referrer.is_some() {
                 if let Some(mut metadata) = link_cache.remove(link) {

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -1,5 +1,9 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::RandomState},
+    future::Future,
+    hash::{BuildHasher, Hasher},
+    io::ErrorKind,
+    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -173,7 +177,10 @@ impl AccessTimeWriter {
     }
 
     async fn flush_one(backend: &Backend, namespace: &str, link: &LinkKind) -> Result<(), Error> {
-        let guard = backend.lock.acquire(&[link.to_string()]).await?;
+        let guard = backend
+            .lock
+            .acquire(&[format!("{namespace}:{link}")])
+            .await?;
         let link_data = backend
             .read_link_reference(namespace, link)
             .await?
@@ -301,6 +308,7 @@ impl Backend {
                 loop {
                     tokio::time::sleep(interval).await;
                     if shutdown_flag.load(Ordering::Acquire) {
+                        flush_backend.flush_access_times().await;
                         return;
                     }
                     flush_backend.flush_access_times().await;
@@ -464,9 +472,7 @@ impl Backend {
 
     async fn cache_invalidate(&self, namespace: &str, link: &LinkKind) {
         if let Some(cache) = &self.cache {
-            let _ = cache
-                .store_value(&Self::cache_key(namespace, link), "", 0)
-                .await;
+            let _ = cache.delete_value(&Self::cache_key(namespace, link)).await;
         }
     }
 
@@ -482,31 +488,42 @@ impl Backend {
         digest: &Digest,
         operations: &[BlobIndexOperation],
     ) -> Result<(), Error> {
-        let path = path_builder::blob_index_path(digest);
+        let shard_path = path_builder::blob_index_shard_path(digest, namespace);
 
         for attempt in 0..MAX_BLOB_INDEX_CAS_RETRIES {
-            let (mut blob_index, etag) = match self.store.read_with_etag(&path).await {
-                Ok((data, etag)) => (serde_json::from_slice::<BlobIndex>(&data)?, etag),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => (BlobIndex::default(), None),
+            let (mut links, etag) = match self.store.read_with_etag(&shard_path).await {
+                Ok((data, etag)) => (
+                    serde_json::from_slice::<HashSet<LinkKind>>(&data).unwrap_or_default(),
+                    etag,
+                ),
+                Err(e) if e.kind() == ErrorKind::NotFound => (HashSet::new(), None),
                 Err(e) => return Err(Error::from(e)),
             };
 
-            apply_blob_index_ops(&mut blob_index, namespace, operations);
+            for op in operations {
+                match op {
+                    BlobIndexOperation::Insert(link) => {
+                        links.insert(link.clone());
+                    }
+                    BlobIndexOperation::Remove(link) => {
+                        links.remove(link);
+                    }
+                }
+            }
 
-            // Write the (possibly empty) index back with CAS. An empty index is written
-            // rather than deleted to avoid a race where a concurrent writer creates a new
-            // entry between our read and a non-conditional delete. The scrub command
-            // handles cleanup of empty blob containers.
-            let content = Bytes::from(serde_json::to_vec(&blob_index)?);
+            // Write the shard back with CAS. Empty shards are written rather than
+            // deleted to avoid a race where a concurrent writer creates a new entry
+            // between our read and a non-conditional delete. Scrub handles cleanup.
+            let content = Bytes::from(serde_json::to_vec(&links)?);
 
             let write_result = if let Some(ref etag) = etag {
                 self.store
-                    .put_object_if_match(&path, etag, content)
+                    .put_object_if_match(&shard_path, etag, content)
                     .await
                     .map(|_| ())
             } else {
                 self.store
-                    .put_object_if_not_exists(&path, content)
+                    .put_object_if_not_exists(&shard_path, content)
                     .await
                     .map(|_| ())
             };
@@ -516,19 +533,16 @@ impl Backend {
                 Err(data_store::Error::PreconditionFailed) => {
                     debug!(
                         digest = %digest,
+                        namespace,
                         attempt,
-                        "Blob index CAS conflict, retrying"
+                        "Blob index shard CAS conflict, retrying"
                     );
                     let jitter_ms = {
-                        use std::hash::{BuildHasher, Hasher};
                         let max = 50u64.saturating_mul(1u64 << attempt.min(4));
                         if max == 0 {
                             0
                         } else {
-                            std::collections::hash_map::RandomState::new()
-                                .build_hasher()
-                                .finish()
-                                % max
+                            RandomState::new().build_hasher().finish() % max
                         }
                     };
                     tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
@@ -541,8 +555,7 @@ impl Backend {
             %digest,
             namespace,
             attempts = MAX_BLOB_INDEX_CAS_RETRIES,
-            "Blob index CAS retries exhausted; blob index may be incomplete for this namespace. \
-             A scrub run can reconcile the blob index."
+            "Blob index shard CAS retries exhausted"
         );
         Err(Error::Lock(format!(
             "blob index CAS retries exhausted for digest {digest} after {MAX_BLOB_INDEX_CAS_RETRIES} attempts"
@@ -668,7 +681,7 @@ impl MetadataStore for Backend {
                                     }
                                 }
                             }
-                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                            Err(e) if e.kind() == ErrorKind::NotFound => {
                                 warn!("Referrer blob not found at {blob_path}, skipping");
                                 None
                             }
@@ -750,18 +763,97 @@ impl MetadataStore for Backend {
 
     #[instrument(skip(self))]
     async fn read_blob_index(&self, digest: &Digest) -> Result<BlobIndex, Error> {
-        let path = path_builder::blob_index_path(digest);
+        // Try sharded format first (refs/{namespace}.json per namespace)
+        let refs_dir = path_builder::blob_index_refs_dir(digest);
+        let mut index = BlobIndex::default();
+        let mut found_shards = false;
+        let mut continuation_token = None;
 
-        let data = match self.store.read(&path).await {
+        loop {
+            let (_, objects, next_token) = self
+                .store
+                .list_prefixes(&refs_dir, "/", 1000, continuation_token, None)
+                .await?;
+
+            if !objects.is_empty() {
+                found_shards = true;
+            }
+
+            let shard_results: Vec<Result<Option<(String, HashSet<LinkKind>)>, Error>> =
+                stream::iter(objects.into_iter().map(|obj| {
+                    let shard_path = format!("{refs_dir}/{obj}");
+                    async move {
+                        match self.store.read(&shard_path).await {
+                            Ok(data) => {
+                                if let Ok(links) =
+                                    serde_json::from_slice::<HashSet<LinkKind>>(&data)
+                                {
+                                    let namespace = obj
+                                        .strip_suffix(".json")
+                                        .unwrap_or(&obj)
+                                        .replace("%2F", "/")
+                                        .replace("%25", "%");
+                                    if !links.is_empty() {
+                                        return Ok(Some((namespace, links)));
+                                    }
+                                }
+                                Ok(None)
+                            }
+                            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+                            Err(e) => Err(Error::from(e)),
+                        }
+                    }
+                }))
+                .buffer_unordered(10)
+                .collect()
+                .await;
+
+            for result in shard_results {
+                if let Some((namespace, links)) = result? {
+                    index.namespace.insert(namespace, links);
+                }
+            }
+
+            continuation_token = next_token;
+            if continuation_token.is_none() {
+                break;
+            }
+        }
+
+        if found_shards {
+            if index.namespace.is_empty() {
+                return Err(Error::ReferenceNotFound);
+            }
+            return Ok(index);
+        }
+
+        // XXX: remove legacy index.json fallback and migration below for v2.0.0
+        let legacy_path = path_builder::blob_index_path(digest);
+        let data = match self.store.read(&legacy_path).await {
             Ok(data) => data,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(e) if e.kind() == ErrorKind::NotFound => {
                 return Err(Error::ReferenceNotFound);
             }
             Err(e) => return Err(e.into()),
         };
-        let index = serde_json::from_slice(&data)?;
+        let blob_index: BlobIndex = serde_json::from_slice(&data).map_err(Error::from)?;
 
-        Ok(index)
+        // Migrate: write shards, then delete legacy file
+        for (namespace, links) in &blob_index.namespace {
+            let ops: Vec<BlobIndexOperation> = links
+                .iter()
+                .map(|link| BlobIndexOperation::Insert(link.clone()))
+                .collect();
+            self.update_blob_index_shard(namespace, digest, &ops)
+                .await?;
+        }
+        self.store.delete(&legacy_path).await?;
+        info!(
+            "Migrated legacy blob index for '{digest}' ({} namespaces)",
+            blob_index.namespace.len()
+        );
+
+        Ok(blob_index)
     }
 
     #[instrument(skip(self))]
@@ -777,26 +869,8 @@ impl MetadataStore for Backend {
                 .await;
         }
 
-        // Fallback: unconditional read-modify-write (caller must hold a lock).
-        let path = path_builder::blob_index_path(digest);
-
-        let mut reference_index = match self.store.read(&path).await {
-            Ok(data) => serde_json::from_slice::<BlobIndex>(&data)?,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => BlobIndex::default(),
-            Err(e) => return Err(e.into()),
-        };
-
-        apply_blob_index_ops(&mut reference_index, namespace, &[operation]);
-
-        if reference_index.namespace.is_empty() {
-            let container = path_builder::blob_container_dir(digest);
-            self.store.delete_prefix(&container).await?;
-        } else {
-            let content = Bytes::from(serde_json::to_vec(&reference_index)?);
-            self.store.put_object(&path, content).await?;
-        }
-
-        Ok(())
+        self.update_blob_index_shard(namespace, digest, &[operation])
+            .await
     }
 
     #[instrument(skip(self))]
@@ -818,7 +892,7 @@ impl MetadataStore for Backend {
                 writer.record(namespace, link).await;
                 Ok(link_data)
             } else {
-                let guard = self.lock.acquire(&[link.to_string()]).await?;
+                let guard = self.lock.acquire(&[format!("{namespace}:{link}")]).await?;
                 let link_data = self.read_link_reference(namespace, link).await?.accessed();
                 if !guard.is_valid() {
                     return Err(Error::Lock(
@@ -910,7 +984,7 @@ impl MetadataStore for Backend {
                 if let Some((link, target, old_target, referrer, media_type, descriptor)) =
                     create_data
                 {
-                    lock_keys.push(link.to_string());
+                    lock_keys.push(format!("{namespace}:{link}"));
                     if !use_cas {
                         lock_keys.push(format!("blob:{target}"));
                         if let Some(ref old) = old_target {
@@ -919,7 +993,7 @@ impl MetadataStore for Backend {
                     }
                     creates.push((link, target, old_target, referrer, media_type, descriptor));
                 } else if let Some((link, Some(meta), referrer)) = delete_data {
-                    lock_keys.push(link.to_string());
+                    lock_keys.push(format!("{namespace}:{link}"));
                     if !use_cas {
                         lock_keys.push(format!("blob:{}", meta.target));
                     }
@@ -1015,6 +1089,7 @@ impl MetadataStore for Backend {
                     let mut metadata = link_cache.remove(link).unwrap_or_else(|| {
                         LinkMetadata::from_digest(target.clone())
                             .with_media_type(media_type.clone())
+                            .with_descriptor((*descriptor).clone())
                     });
 
                     if let Some(manifest_digest) = referrer {
@@ -1107,9 +1182,8 @@ impl MetadataStore for Backend {
                 tracked_delete_writes
                     .iter()
                     .map(|(link, metadata)| {
-                        let fut: std::pin::Pin<
-                            Box<dyn std::future::Future<Output = Result<(), Error>> + Send + '_>,
-                        > = Box::pin(self.write_link_reference(namespace, link, metadata));
+                        let fut: Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> =
+                            Box::pin(self.write_link_reference(namespace, link, metadata));
                         fut
                     })
                     .chain(
@@ -1117,12 +1191,8 @@ impl MetadataStore for Backend {
                             .iter()
                             .chain(non_tracked_delete_links.iter())
                             .map(|link| {
-                                let fut: std::pin::Pin<
-                                    Box<
-                                        dyn std::future::Future<Output = Result<(), Error>>
-                                            + Send
-                                            + '_,
-                                    >,
+                                let fut: Pin<
+                                    Box<dyn Future<Output = Result<(), Error>> + Send + '_>,
                                 > = Box::pin(self.delete_link_reference(namespace, link));
                                 fut
                             }),
@@ -1165,25 +1235,13 @@ impl MetadataStore for Backend {
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()?;
             } else {
-                // Without conditional write support, blob index updates run under the
-                // lock (blob:{digest} keys are included in lock_keys above).
-                join_all(pending_blob_ops.iter().map(|(digest, ops)| async move {
-                    let path = path_builder::blob_index_path(digest);
-                    let mut blob_index = match self.store.read(&path).await {
-                        Ok(data) => serde_json::from_slice::<BlobIndex>(&data)?,
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => BlobIndex::default(),
-                        Err(e) => return Err(Error::from(e)),
-                    };
-                    apply_blob_index_ops(&mut blob_index, namespace, ops);
-                    if blob_index.namespace.is_empty() {
-                        let container = path_builder::blob_container_dir(digest);
-                        self.store.delete_prefix(&container).await?;
-                    } else {
-                        let content = Bytes::from(serde_json::to_vec(&blob_index)?);
-                        self.store.put_object(&path, content).await?;
-                    }
-                    Ok(())
-                }))
+                // Without conditional write support, blob index shard updates run
+                // under the lock (blob:{digest} keys are included in lock_keys above).
+                join_all(
+                    pending_blob_ops
+                        .iter()
+                        .map(|(digest, ops)| self.update_blob_index_shard(namespace, digest, ops)),
+                )
                 .await
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()?;
@@ -1211,27 +1269,6 @@ impl MetadataStore for Backend {
     }
 }
 
-fn apply_blob_index_ops(
-    blob_index: &mut BlobIndex,
-    namespace: &str,
-    operations: &[BlobIndexOperation],
-) {
-    let mut ns_links = blob_index.namespace.remove(namespace).unwrap_or_default();
-    for op in operations {
-        match op {
-            BlobIndexOperation::Insert(link) => {
-                ns_links.insert(link.clone());
-            }
-            BlobIndexOperation::Remove(link) => {
-                ns_links.remove(link);
-            }
-        }
-    }
-    if !ns_links.is_empty() {
-        blob_index.namespace.insert(namespace.to_string(), ns_links);
-    }
-}
-
 fn is_tracked_link(link: &LinkKind) -> bool {
     matches!(
         link,
@@ -1240,6 +1277,41 @@ fn is_tracked_link(link: &LinkKind) -> bool {
 }
 
 impl Backend {
+    /// Unconditional read-modify-write on a namespace shard (caller must hold lock).
+    async fn update_blob_index_shard(
+        &self,
+        namespace: &str,
+        digest: &Digest,
+        operations: &[BlobIndexOperation],
+    ) -> Result<(), Error> {
+        let shard_path = path_builder::blob_index_shard_path(digest, namespace);
+        let mut links: HashSet<LinkKind> = match self.store.read(&shard_path).await {
+            Ok(data) => serde_json::from_slice(&data).unwrap_or_default(),
+            Err(e) if e.kind() == ErrorKind::NotFound => HashSet::new(),
+            Err(e) => return Err(e.into()),
+        };
+
+        for operation in operations {
+            match operation {
+                BlobIndexOperation::Insert(link) => {
+                    links.insert(link.clone());
+                }
+                BlobIndexOperation::Remove(link) => {
+                    links.remove(link);
+                }
+            }
+        }
+
+        if links.is_empty() {
+            self.store.delete(&shard_path).await?;
+        } else {
+            let content = Bytes::from(serde_json::to_vec(&links)?);
+            self.store.put_object(&shard_path, content).await?;
+        }
+
+        Ok(())
+    }
+
     async fn read_namespace_registry(&self) -> Result<Option<NamespaceRegistry>, Error> {
         let path = path_builder::namespace_registry_path();
         match self.store.read(&path).await {
@@ -1250,7 +1322,7 @@ impl Backend {
                     Ok(None)
                 }
             },
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
             Err(e) => Err(Error::from(e)),
         }
     }
@@ -1268,7 +1340,31 @@ impl Backend {
         let path = path_builder::namespace_registry_path();
 
         if self.supports_conditional_writes {
-            self.store.put_object(&path, content).await?;
+            // Use CAS to avoid stomping concurrent register_namespace_cas writes.
+            // Read current ETag (if any), then write with If-Match / If-None-Match.
+            let etag = match self.store.read_with_etag(&path).await {
+                Ok((_, etag)) => etag,
+                Err(e) if e.kind() == ErrorKind::NotFound => None,
+                Err(e) => return Err(Error::from(e)),
+            };
+            let write_result = if let Some(ref etag) = etag {
+                self.store
+                    .put_object_if_match(&path, etag, content)
+                    .await
+                    .map(|_| ())
+            } else {
+                self.store
+                    .put_object_if_not_exists(&path, content)
+                    .await
+                    .map(|_| ())
+            };
+            match write_result {
+                Ok(()) => {}
+                Err(data_store::Error::PreconditionFailed) => {
+                    debug!("Namespace registry rebuild lost CAS race; concurrent write wins");
+                }
+                Err(e) => return Err(Error::StorageBackend(e.to_string())),
+            }
         } else {
             let lock_key = "namespace_registry".to_string();
             let guard = self.lock.acquire(&[lock_key]).await?;
@@ -1297,7 +1393,7 @@ impl Backend {
 
         let mut registry = match self.store.read(&path).await {
             Ok(data) => serde_json::from_slice::<NamespaceRegistry>(&data).unwrap_or_default(),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => NamespaceRegistry::default(),
+            Err(e) if e.kind() == ErrorKind::NotFound => NamespaceRegistry::default(),
             Err(e) => {
                 guard.release().await;
                 return Err(Error::from(e));
@@ -1331,28 +1427,17 @@ impl Backend {
                     // Corrupt JSON: keep the ETag so we can overwrite with CAS
                     Err(_) => (NamespaceRegistry::default(), etag),
                 },
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    (NamespaceRegistry::default(), None)
-                }
+                Err(e) if e.kind() == ErrorKind::NotFound => (NamespaceRegistry::default(), None),
                 Err(e) => return Err(Error::from(e)),
             };
 
-            if registry
-                .namespaces
-                .binary_search(&namespace.to_string())
-                .is_ok()
-            {
+            let Err(pos) = registry.namespaces.binary_search(&namespace.to_string()) else {
                 self.known_namespaces
                     .lock()
                     .await
                     .insert(namespace.to_string());
                 return Ok(());
-            }
-
-            let pos = registry
-                .namespaces
-                .binary_search(&namespace.to_string())
-                .unwrap_err();
+            };
             registry.namespaces.insert(pos, namespace.to_string());
 
             let content = Bytes::from(serde_json::to_vec(&registry)?);
@@ -1382,15 +1467,11 @@ impl Backend {
                         attempt, "Namespace registry CAS conflict, retrying"
                     );
                     let jitter_ms = {
-                        use std::hash::{BuildHasher, Hasher};
                         let max = 50u64.saturating_mul(1u64 << attempt.min(4));
                         if max == 0 {
                             0
                         } else {
-                            std::collections::hash_map::RandomState::new()
-                                .build_hasher()
-                                .finish()
-                                % max
+                            RandomState::new().build_hasher().finish() % max
                         }
                     };
                     tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
@@ -1451,7 +1532,7 @@ impl Backend {
         let link_path = path_builder::link_path(link, namespace);
         match self.store.read(&link_path).await {
             Ok(data) => LinkMetadata::from_bytes(data),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(Error::ReferenceNotFound),
+            Err(e) if e.kind() == ErrorKind::NotFound => Err(Error::ReferenceNotFound),
             Err(e) => Err(e.into()),
         }
     }
@@ -1479,7 +1560,7 @@ impl Backend {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{str::FromStr, time::Instant};
 
     use super::*;
     use crate::{
@@ -1605,7 +1686,7 @@ mod tests {
         assert_eq!(meta.target, digest_a);
 
         // Wait for cache to expire
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        tokio::time::sleep(Duration::from_millis(1100)).await;
 
         // Write new data directly to S3 (bypassing cache invalidation)
         let new_metadata = LinkMetadata::from_digest(digest_b.clone());
@@ -1918,7 +1999,7 @@ mod tests {
         backend.read_link(namespace, &tag, true).await.unwrap();
 
         // Wait for the background flush (debounce = 1s, wait 1.5s)
-        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+        tokio::time::sleep(Duration::from_millis(1500)).await;
 
         // Read directly from S3: accessed_at should now be set
         let raw = backend.read_link_reference(namespace, &tag).await.unwrap();
@@ -1949,7 +2030,7 @@ mod tests {
         backend.update_links(namespace, &ops).await.unwrap();
 
         // Call read_link with update_access_time 10 times rapidly
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         for _ in 0..10 {
             let meta = backend.read_link(namespace, &tag, true).await.unwrap();
             assert_eq!(meta.target, digest);
@@ -1958,7 +2039,7 @@ mod tests {
 
         // All 10 reads should complete quickly since writes are deferred
         assert!(
-            elapsed < std::time::Duration::from_secs(1),
+            elapsed < Duration::from_secs(1),
             "10 deferred reads should complete in under 1 second, took {elapsed:?}"
         );
 
@@ -2113,7 +2194,7 @@ mod tests {
         backend.update_links(namespace, &ops).await.unwrap();
 
         // Spawn 50 concurrent read_link calls with update_access_time=true
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         let mut handles = Vec::new();
         for _ in 0..50 {
             let backend = backend.clone();
@@ -2131,7 +2212,7 @@ mod tests {
         let elapsed = start.elapsed();
 
         assert!(
-            elapsed < std::time::Duration::from_secs(2),
+            elapsed < Duration::from_secs(2),
             "50 concurrent deferred reads should complete within 2 seconds, took {elapsed:?}"
         );
     }
@@ -2167,7 +2248,7 @@ mod tests {
 
         // Flush and measure time; concurrent flush should be significantly
         // faster than sequential because each flush_one involves lock + read + write
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         backend.flush_access_times().await;
         let elapsed = start.elapsed();
 
@@ -2185,7 +2266,7 @@ mod tests {
         // processing of 20 entries would take much longer. This is a soft
         // assertion to validate concurrency is happening.
         assert!(
-            elapsed < std::time::Duration::from_secs(5),
+            elapsed < Duration::from_secs(5),
             "Flushing 20 entries concurrently should complete within 5 seconds, took {elapsed:?}"
         );
     }

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -188,6 +188,8 @@ pub struct Backend {
     access_time_writer: Option<AccessTimeWriter>,
 }
 
+const MAX_UPDATE_RETRIES: u32 = 10;
+
 impl Backend {
     pub fn new(config: &BackendConfig) -> Result<Self, Error> {
         info!("Using S3 metadata-store backend");
@@ -689,6 +691,7 @@ impl MetadataStore for Backend {
             return Ok(());
         }
 
+        let mut update_retries = MAX_UPDATE_RETRIES;
         loop {
             let mut link_cache: HashMap<LinkKind, LinkMetadata> = HashMap::new();
 
@@ -777,6 +780,13 @@ impl MetadataStore for Backend {
                 .any(|(_, _, current_target, expected)| *current_target != *expected)
             {
                 guard.release().await;
+                if update_retries == 0 {
+                    return Err(Error::Lock(
+                        "update_links exceeded maximum retries due to concurrent modifications"
+                            .into(),
+                    ));
+                }
+                update_retries -= 1;
                 continue;
             }
             for (link, metadata, _, _) in validation_results {
@@ -815,6 +825,13 @@ impl MetadataStore for Backend {
             }
             if needs_retry {
                 guard.release().await;
+                if update_retries == 0 {
+                    return Err(Error::Lock(
+                        "update_links exceeded maximum retries due to concurrent modifications"
+                            .into(),
+                    ));
+                }
+                update_retries -= 1;
                 continue;
             }
 

--- a/src/registry/metadata_store/s3/mod.rs
+++ b/src/registry/metadata_store/s3/mod.rs
@@ -1983,7 +1983,8 @@ impl Backend {
                 .await
             {
                 Ok(_) => return Ok(link_data),
-                Err(data_store::Error::PreconditionFailed) => continue,
+                Err(data_store::Error::PreconditionFailed) => {}
+
                 Err(e) => return Err(Error::StorageBackend(e.to_string())),
             }
         }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -205,13 +205,13 @@ pub mod test_utils {
         // Create a test blob
         let digest = registry.blob_store.create_blob(content).await.unwrap();
 
-        // Create a tag to ensure the namespace exists
         let tag_link = LinkKind::Tag("latest".to_string());
+        let layer_link = LinkKind::Layer(digest.clone());
         let mut tx = registry.metadata_store.begin_transaction(namespace);
         tx.create_link(&tag_link, &digest);
+        tx.create_link(&layer_link, &digest);
         tx.commit().await.unwrap();
 
-        // Verify the blob index is updated
         let blob_index = registry
             .metadata_store
             .read_blob_index(&digest)
@@ -219,7 +219,7 @@ pub mod test_utils {
             .unwrap();
         assert!(blob_index.namespace.contains_key(namespace));
         let namespace_links = blob_index.namespace.get(namespace).unwrap();
-        assert!(namespace_links.contains(&tag_link));
+        assert!(namespace_links.contains(&layer_link));
 
         // Create a non-pull-through repository
         let cache = cache::Config::Memory.to_backend().unwrap();

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -125,12 +125,14 @@ impl Registry {
         self.metadata_store.flush_access_times().await;
     }
 
-    pub async fn check_ready(&self) -> Result<(), Error> {
+    pub async fn check_ready(
+        &self,
+    ) -> Result<Option<metadata_store::ConditionalCapabilities>, Error> {
         self.metadata_store
             .list_namespaces(1, None)
             .await
-            .map(|_| ())
-            .map_err(|e| Error::Internal(format!("storage backend not ready: {e}")))
+            .map_err(|e| Error::Internal(format!("storage backend not ready: {e}")))?;
+        Ok(self.metadata_store.conditional_capabilities())
     }
 
     #[instrument]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -125,6 +125,14 @@ impl Registry {
         self.metadata_store.flush_access_times().await;
     }
 
+    pub async fn check_ready(&self) -> Result<(), Error> {
+        self.metadata_store
+            .list_namespaces(1, None)
+            .await
+            .map(|_| ())
+            .map_err(|e| Error::Internal(format!("storage backend not ready: {e}")))
+    }
+
     #[instrument]
     pub fn get_repository_for_namespace(
         &self,

--- a/src/registry/path_builder.rs
+++ b/src/registry/path_builder.rs
@@ -31,10 +31,14 @@ pub fn namespace_registry_shard_path(namespace: &str) -> String {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-pub fn namespace_shard_key(namespace: &str) -> String {
+pub fn shard_key(value: &str) -> String {
     let mut hasher = DefaultHasher::new();
-    namespace.hash(&mut hasher);
+    value.hash(&mut hasher);
     format!("{:02x}", hasher.finish() as u8)
+}
+
+pub fn namespace_shard_key(namespace: &str) -> String {
+    shard_key(namespace)
 }
 
 fn blob_dir(digest: &Digest) -> String {
@@ -304,9 +308,11 @@ mod tests {
 
         let path = namespace_registry_shard_path("my-repo");
         assert!(path.starts_with("_registry/ns/"));
-        assert!(std::path::Path::new(&path)
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("json")));
+        assert!(
+            std::path::Path::new(&path)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+        );
 
         // Same namespace always maps to the same shard
         assert_eq!(

--- a/src/registry/path_builder.rs
+++ b/src/registry/path_builder.rs
@@ -1,3 +1,8 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
 use crate::{oci::Digest, registry::metadata_store::link_kind::LinkKind};
 
 const BLOBS_ROOT: &str = "v2/blobs";
@@ -14,6 +19,22 @@ pub fn repository_dir() -> &'static str {
 
 pub fn namespace_registry_path() -> String {
     format!("{REGISTRY_ROOT}/namespaces.json")
+}
+
+pub fn namespace_registry_shard_dir() -> String {
+    format!("{REGISTRY_ROOT}/ns")
+}
+
+pub fn namespace_registry_shard_path(namespace: &str) -> String {
+    let shard = namespace_shard_key(namespace);
+    format!("{REGISTRY_ROOT}/ns/{shard}.json")
+}
+
+#[allow(clippy::cast_possible_truncation)]
+pub fn namespace_shard_key(namespace: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    namespace.hash(&mut hasher);
+    format!("{:02x}", hasher.finish() as u8)
 }
 
 fn blob_dir(digest: &Digest) -> String {
@@ -275,5 +296,27 @@ mod tests {
             link_container_path(&manifest_link, "ns"),
             "v2/repositories/ns/_manifests/index/sha256/index123/sha256/child456"
         );
+    }
+
+    #[test]
+    fn test_namespace_registry_shard_paths() {
+        assert_eq!(namespace_registry_shard_dir(), "_registry/ns");
+
+        let path = namespace_registry_shard_path("my-repo");
+        assert!(path.starts_with("_registry/ns/"));
+        assert!(std::path::Path::new(&path)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("json")));
+
+        // Same namespace always maps to the same shard
+        assert_eq!(
+            namespace_registry_shard_path("my-repo"),
+            namespace_registry_shard_path("my-repo")
+        );
+
+        // Shard key is a 2-char hex string
+        let key = namespace_shard_key("my-repo");
+        assert_eq!(key.len(), 2);
+        assert!(key.chars().all(|c| c.is_ascii_hexdigit()));
     }
 }

--- a/src/registry/path_builder.rs
+++ b/src/registry/path_builder.rs
@@ -2,6 +2,7 @@ use crate::{oci::Digest, registry::metadata_store::link_kind::LinkKind};
 
 const BLOBS_ROOT: &str = "v2/blobs";
 const REPOS_ROOT: &str = "v2/repositories";
+const REGISTRY_ROOT: &str = "_registry";
 
 pub fn blobs_root_dir() -> &'static str {
     BLOBS_ROOT
@@ -9,6 +10,10 @@ pub fn blobs_root_dir() -> &'static str {
 
 pub fn repository_dir() -> &'static str {
     REPOS_ROOT
+}
+
+pub fn namespace_registry_path() -> String {
+    format!("{REGISTRY_ROOT}/namespaces.json")
 }
 
 fn blob_dir(digest: &Digest) -> String {

--- a/src/registry/path_builder.rs
+++ b/src/registry/path_builder.rs
@@ -33,6 +33,17 @@ pub fn blob_index_path(digest: &Digest) -> String {
     format!("{}/index.json", blob_dir(digest))
 }
 
+pub fn blob_index_refs_dir(digest: &Digest) -> String {
+    format!("{}/refs", blob_dir(digest))
+}
+
+pub fn blob_index_shard_path(digest: &Digest, namespace: &str) -> String {
+    // Encode namespace as a safe filename: percent-encode '/' and '%' to avoid
+    // ambiguity (namespaces can contain underscores, so '/' -> '_' is lossy).
+    let safe_ns = namespace.replace('%', "%25").replace('/', "%2F");
+    format!("{}/refs/{safe_ns}.json", blob_dir(digest))
+}
+
 pub fn blob_container_dir(digest: &Digest) -> String {
     blob_dir(digest)
 }

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -114,17 +114,21 @@ impl S3RegistryTestCase {
         .unwrap();
         let blob_store = Arc::new(blob_store);
 
-        let metadata_store = metadata_store::s3::Backend::new(&metadata_store::s3::BackendConfig {
-            access_key_id: "root".to_string(),
-            secret_key: "roottoor".to_string(),
-            endpoint: "http://127.0.0.1:9000".to_string(),
-            region: "region".to_string(),
-            bucket: "registry".to_string(),
-            key_prefix: key_prefix.clone(),
-            lock_strategy: metadata_store::LockStrategy::Memory,
-            link_cache_ttl: 0,
-            access_time_debounce_secs: 0,
-        })
+        let metadata_store = metadata_store::s3::Backend::new(
+            &metadata_store::s3::BackendConfig {
+                access_key_id: "root".to_string(),
+                secret_key: "roottoor".to_string(),
+                endpoint: "http://127.0.0.1:9000".to_string(),
+                region: "region".to_string(),
+                bucket: "registry".to_string(),
+                key_prefix: key_prefix.clone(),
+                lock_strategy: metadata_store::LockStrategy::Memory,
+                link_cache_ttl: 0,
+                access_time_debounce_secs: 0,
+                capabilities: None,
+            },
+            None,
+        )
         .unwrap();
         let metadata_store = Arc::new(metadata_store);
 

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -43,7 +43,7 @@ impl FSRegistryTestCase {
         let metadata_store = metadata_store::fs::Backend::new(&metadata_store::fs::BackendConfig {
             root_dir: path,
             sync_to_disk: false,
-            redis: None,
+            lock_strategy: metadata_store::LockStrategy::Memory,
         })
         .unwrap();
         let metadata_store = Arc::new(metadata_store);
@@ -121,7 +121,7 @@ impl S3RegistryTestCase {
             region: "region".to_string(),
             bucket: "registry".to_string(),
             key_prefix: key_prefix.clone(),
-            redis: None,
+            lock_strategy: metadata_store::LockStrategy::Memory,
             link_cache_ttl: 0,
             access_time_debounce_secs: 0,
         })

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -4,6 +4,7 @@ use std::{
     sync::Arc,
 };
 
+use async_trait::async_trait;
 use notify::{Event, EventKind, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -13,8 +14,9 @@ use crate::{
     configuration::{Configuration, Error, ServerConfig},
 };
 
+#[async_trait]
 pub trait ConfigNotifier: Send + Sync {
-    fn notify_config_change(&self, config: &Configuration);
+    async fn notify_config_change(&self, config: &Configuration);
     fn notify_tls_config_change(&self, tls: &ServerTlsConfig);
 }
 
@@ -145,7 +147,7 @@ async fn watch_config_loop(
                 info!("Configuration change detected, reloading");
                 match Configuration::load(&config_path) {
                     Ok(ref cfg) => {
-                        notifier.notify_config_change(cfg);
+                        notifier.notify_config_change(cfg).await;
                         info!("Configuration reloaded");
                     }
                     Err(e) => warn!("Failed to reload configuration: {e}"),
@@ -220,8 +222,9 @@ server_private_key = "{key_path}"
         }
     }
 
+    #[async_trait]
     impl ConfigNotifier for TestNotifier {
-        fn notify_config_change(&self, config: &Configuration) {
+        async fn notify_config_change(&self, config: &Configuration) {
             self.config_changes.lock().unwrap().push(config.clone());
         }
 


### PR DESCRIPTION
Support for a pure S3 metadata store making the redis lock backend completely irrelevant for multi replica deployments.

This opens the door to massive scale deployment.

NOTE: not all S3-compatible backends support conditional operations. AWS and Exoscale does.

- [x] Conditional PUT
- [x] Conditional DELETE