### PR TITLE
fix: return Content-Type on manifest GET when body omits mediaType

### DIFF
--- a/src/registry/manifest.rs
+++ b/src/registry/manifest.rs
@@ -257,7 +257,7 @@ impl Registry {
         })?;
 
         Ok(GetManifestResponse {
-            media_type: manifest.media_type,
+            media_type: link.media_type.or(manifest.media_type),
             digest: link.target,
             content,
         })


### PR DESCRIPTION
Fix for https://github.com/project-angos/angos/issues/77