### PR TITLE
Improve pre-signed URLs compatibility

### DIFF
--- a/conformance/config-s3-lock.toml
+++ b/conformance/config-s3-lock.toml
@@ -4,7 +4,8 @@ port = 8000
 
 [global]
 # 307 temporary redirections are not defined in the OCI spec, so zb don't (seems to) support 307 it.
-enable_redirect = false
+enable_blob_redirect = false
+enable_manifest_redirect = false
 
 [blob_store.s3]
 # Test credentials for local MinIO instance

--- a/conformance/config-s3.toml
+++ b/conformance/config-s3.toml
@@ -4,7 +4,8 @@ port = 8000
 
 [global]
 # 307 temporary redirections are not defined in the OCI spec, so zb don't (seems to) support 307 it.
-enable_redirect = false
+enable_blob_redirect = false
+enable_manifest_redirect = false
 
 [blob_store.s3]
 access_key_id = "root"

--- a/doc/explanation/architecture.md
+++ b/doc/explanation/architecture.md
@@ -120,9 +120,9 @@ sequenceDiagram
 ```
 
 With S3 storage, blob and manifest GET requests redirect to pre-signed URLs by default, avoiding proxying data through the registry.
-This can be disabled with `enable_redirect = false` in `[global]`, in which case the registry proxies all responses.
+This can be disabled per object kind with `enable_blob_redirect = false` and/or `enable_manifest_redirect = false` in `[global]`, in which case the registry proxies the corresponding responses.
 
-**When redirects are enabled** (`enable_redirect = true`, the default):
+**When redirects are enabled** (both flags default to `true`):
 - Clients must have direct network access to the S3 endpoint
 - Pre-signed URLs expire — very slow downloads may fail
 - S3 bucket policies must allow access from client IP ranges

--- a/doc/how-to/upgrade.md
+++ b/doc/how-to/upgrade.md
@@ -103,3 +103,42 @@ delete_if_match = true
 ```
 
 See [Conditional Capabilities](../reference/configuration.md#conditional-capabilities-metadata_stores3capabilities) in the configuration reference for details on when to use this and which providers support each capability.
+
+---
+
+## 1.1.x → Next
+
+### Redirect Configuration Split
+
+#### What Changed
+
+`global.enable_redirect` has been deprecated and replaced by two separate flags:
+
+- `global.enable_blob_redirect` — controls HTTP 307 redirects for blob (layer/config) downloads.
+- `global.enable_manifest_redirect` — controls HTTP 307 redirects for manifest downloads.
+
+Both default to `true`, preserving historical behavior. The old `enable_redirect` field is still accepted as a fallback for both new flags and will emit a deprecation warning at startup.
+
+Additionally, presigned manifest URLs now include a `response-content-type` query parameter so that S3 serves the correct OCI/Docker media type after a redirect, rather than `binary/octet-stream`. This fixes `podman pull` and `skopeo copy` failures against Angos deployments with S3-backed storage and redirects enabled.
+
+#### Migration
+
+**If you had `enable_redirect = false` as a workaround for Podman/Skopeo manifest parsing errors**, you can now enable redirects:
+
+```toml
+[global]
+enable_blob_redirect = true
+enable_manifest_redirect = true
+```
+
+Or simply remove the `enable_redirect = false` line, since the default for both new flags is `true`.
+
+**If you want to keep redirects disabled**:
+
+```toml
+[global]
+enable_blob_redirect = false
+enable_manifest_redirect = false
+```
+
+**If you want to keep using `enable_redirect`**, no immediate action is required. The field continues to work as a fallback but will print a warning at startup. Update to the new fields at your convenience.

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -51,7 +51,9 @@ When omitted, the server runs without TLS (insecure).
 | `max_concurrent_requests`   | usize    | `64`     | Tokio worker threads (see Performance Tuning) |
 | `max_concurrent_cache_jobs` | usize    | `4`      | Maximum concurrent cache jobs               |
 | `update_pull_time`          | bool     | `false`  | Track pull times for retention policies     |
-| `enable_redirect`           | bool     | `true`   | Allow HTTP 307 redirects for blob and manifest downloads |
+| `enable_redirect`           | bool     | —        | **Deprecated.** Fallback for both fields below when unset. |
+| `enable_blob_redirect`      | bool     | `true`   | Allow HTTP 307 redirects for blob downloads. |
+| `enable_manifest_redirect`  | bool     | `true`   | Allow HTTP 307 redirects for manifest downloads. Manifest bodies served via `response-content-type` to preserve the media type across redirects. |
 | `immutable_tags`            | bool     | `false`  | Global immutable tags default               |
 | `immutable_tags_exclusions` | [string] | `[]`     | Regex patterns for mutable tags             |
 | `authorization_webhook`     | string   | -        | Name of webhook for authorization           |

--- a/src/command/server/auth/authorizer.rs
+++ b/src/command/server/auth/authorizer.rs
@@ -704,7 +704,8 @@ mod tests {
 
         let registry_config = RegistryConfig::new()
             .update_pull_time(config.global.update_pull_time)
-            .enable_redirect(config.global.enable_redirect)
+            .enable_blob_redirect(config.global.resolved_enable_blob_redirect())
+            .enable_manifest_redirect(config.global.resolved_enable_manifest_redirect())
             .concurrent_cache_jobs(config.global.max_concurrent_cache_jobs)
             .global_immutable_tags(config.global.immutable_tags)
             .global_immutable_tags_exclusions(config.global.immutable_tags_exclusions.clone());

--- a/src/command/server/command.rs
+++ b/src/command/server/command.rs
@@ -141,7 +141,8 @@ async fn build_registry(
 
     let registry_config = RegistryConfig::new()
         .update_pull_time(config.global.update_pull_time)
-        .enable_redirect(config.global.enable_redirect)
+        .enable_blob_redirect(config.global.resolved_enable_blob_redirect())
+        .enable_manifest_redirect(config.global.resolved_enable_manifest_redirect())
         .concurrent_cache_jobs(config.global.max_concurrent_cache_jobs)
         .global_immutable_tags(config.global.immutable_tags)
         .global_immutable_tags_exclusions(config.global.immutable_tags_exclusions.clone());
@@ -610,7 +611,8 @@ mod tests {
 
         let registry_config = RegistryConfig::new()
             .update_pull_time(config.global.update_pull_time)
-            .enable_redirect(config.global.enable_redirect)
+            .enable_blob_redirect(config.global.resolved_enable_blob_redirect())
+            .enable_manifest_redirect(config.global.resolved_enable_manifest_redirect())
             .concurrent_cache_jobs(config.global.max_concurrent_cache_jobs)
             .global_immutable_tags(config.global.immutable_tags)
             .global_immutable_tags_exclusions(config.global.immutable_tags_exclusions.clone());

--- a/src/command/server/http_server.rs
+++ b/src/command/server/http_server.rs
@@ -1175,7 +1175,8 @@ mod tests {
         let repositories = Arc::new(HashMap::new());
         let registry_config = RegistryConfig::new()
             .update_pull_time(false)
-            .enable_redirect(true)
+            .enable_blob_redirect(true)
+            .enable_manifest_redirect(true)
             .concurrent_cache_jobs(10)
             .global_immutable_tags(false)
             .global_immutable_tags_exclusions(Vec::new());
@@ -1233,7 +1234,8 @@ mod tests {
         let repositories = Arc::new(HashMap::new());
         let registry_config = RegistryConfig::new()
             .update_pull_time(false)
-            .enable_redirect(true)
+            .enable_blob_redirect(true)
+            .enable_manifest_redirect(true)
             .concurrent_cache_jobs(10)
             .global_immutable_tags(false)
             .global_immutable_tags_exclusions(Vec::new());

--- a/src/command/server/listeners/insecure.rs
+++ b/src/command/server/listeners/insecure.rs
@@ -317,7 +317,8 @@ mod tests {
 
         let registry_config = RegistryConfig::new()
             .update_pull_time(false)
-            .enable_redirect(true)
+            .enable_blob_redirect(true)
+            .enable_manifest_redirect(true)
             .concurrent_cache_jobs(10)
             .global_immutable_tags(false)
             .global_immutable_tags_exclusions(Vec::new());
@@ -578,7 +579,8 @@ mod tests {
 
         let registry_config = RegistryConfig::new()
             .update_pull_time(false)
-            .enable_redirect(true)
+            .enable_blob_redirect(true)
+            .enable_manifest_redirect(true)
             .concurrent_cache_jobs(10)
             .global_immutable_tags(false)
             .global_immutable_tags_exclusions(Vec::new());

--- a/src/command/server/server_context.rs
+++ b/src/command/server/server_context.rs
@@ -172,7 +172,8 @@ pub mod tests {
 
         let registry_config = RegistryConfig::new()
             .update_pull_time(false)
-            .enable_redirect(true)
+            .enable_blob_redirect(true)
+            .enable_manifest_redirect(true)
             .concurrent_cache_jobs(10)
             .global_immutable_tags(false)
             .global_immutable_tags_exclusions(Vec::new());
@@ -223,7 +224,8 @@ pub mod tests {
 
         let registry_config = RegistryConfig::new()
             .update_pull_time(config.global.update_pull_time)
-            .enable_redirect(config.global.enable_redirect)
+            .enable_blob_redirect(config.global.resolved_enable_blob_redirect())
+            .enable_manifest_redirect(config.global.resolved_enable_manifest_redirect())
             .concurrent_cache_jobs(config.global.max_concurrent_cache_jobs)
             .global_immutable_tags(config.global.immutable_tags)
             .global_immutable_tags_exclusions(config.global.immutable_tags_exclusions.clone());
@@ -1068,7 +1070,8 @@ pub mod tests {
 
         let registry_config = RegistryConfig::new()
             .update_pull_time(false)
-            .enable_redirect(false)
+            .enable_blob_redirect(false)
+            .enable_manifest_redirect(false)
             .concurrent_cache_jobs(4)
             .global_immutable_tags(false)
             .global_immutable_tags_exclusions(Vec::new());
@@ -1188,7 +1191,8 @@ pub mod tests {
 
         let registry_config = RegistryConfig::new()
             .update_pull_time(config.global.update_pull_time)
-            .enable_redirect(config.global.enable_redirect)
+            .enable_blob_redirect(config.global.resolved_enable_blob_redirect())
+            .enable_manifest_redirect(config.global.resolved_enable_manifest_redirect())
             .concurrent_cache_jobs(config.global.max_concurrent_cache_jobs)
             .global_immutable_tags(config.global.immutable_tags)
             .global_immutable_tags_exclusions(config.global.immutable_tags_exclusions.clone());

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use serde::Deserialize;
-use tracing::info;
+use tracing::{info, warn};
 
 mod error;
 
@@ -60,8 +60,12 @@ pub struct GlobalConfig {
     pub max_concurrent_cache_jobs: usize,
     #[serde(default = "GlobalConfig::default_update_pull_time")]
     pub update_pull_time: bool,
-    #[serde(default = "GlobalConfig::default_enable_redirect")]
-    pub enable_redirect: bool,
+    #[serde(default)]
+    pub enable_redirect: Option<bool>,
+    #[serde(default)]
+    pub enable_blob_redirect: Option<bool>,
+    #[serde(default)]
+    pub enable_manifest_redirect: Option<bool>,
     #[serde(default)]
     pub access_policy: AccessPolicyConfig,
     #[serde(default)]
@@ -104,7 +108,9 @@ impl Default for GlobalConfig {
             max_concurrent_requests: GlobalConfig::default_max_concurrent_requests(),
             max_concurrent_cache_jobs: GlobalConfig::default_max_concurrent_cache_jobs(),
             update_pull_time: GlobalConfig::default_update_pull_time(),
-            enable_redirect: GlobalConfig::default_enable_redirect(),
+            enable_redirect: None,
+            enable_blob_redirect: None,
+            enable_manifest_redirect: None,
             access_policy: AccessPolicyConfig::default(),
             retention_policy: RetentionPolicyConfig::default(),
             immutable_tags: false,
@@ -128,8 +134,16 @@ impl GlobalConfig {
         false
     }
 
-    fn default_enable_redirect() -> bool {
-        true
+    pub fn resolved_enable_blob_redirect(&self) -> bool {
+        self.enable_blob_redirect
+            .or(self.enable_redirect)
+            .unwrap_or(true)
+    }
+
+    pub fn resolved_enable_manifest_redirect(&self) -> bool {
+        self.enable_manifest_redirect
+            .or(self.enable_redirect)
+            .unwrap_or(true)
     }
 }
 
@@ -166,6 +180,15 @@ impl Configuration {
 
         config.validate()?;
         Ok(config)
+    }
+
+    pub fn log_deprecations(&self) {
+        if self.global.enable_redirect.is_some() {
+            warn!(
+                "'global.enable_redirect' is deprecated; use \
+                 'global.enable_blob_redirect' and 'global.enable_manifest_redirect' instead"
+            );
+        }
     }
 
     pub fn validate(&self) -> Result<(), Error> {
@@ -1547,5 +1570,54 @@ mod tests {
             err_msg.contains("S3 lock strategy") || err_msg.contains("filesystem"),
             "Error should explain S3 lock strategy is unsupported for FS store, got: {err_msg}"
         );
+    }
+
+    #[test]
+    fn test_redirect_resolver_only_enable_redirect_true() {
+        let config = GlobalConfig {
+            enable_redirect: Some(true),
+            ..GlobalConfig::default()
+        };
+        assert!(config.resolved_enable_blob_redirect());
+        assert!(config.resolved_enable_manifest_redirect());
+    }
+
+    #[test]
+    fn test_redirect_resolver_only_enable_redirect_false() {
+        let config = GlobalConfig {
+            enable_redirect: Some(false),
+            ..GlobalConfig::default()
+        };
+        assert!(!config.resolved_enable_blob_redirect());
+        assert!(!config.resolved_enable_manifest_redirect());
+    }
+
+    #[test]
+    fn test_redirect_resolver_both_new_fields_set() {
+        let config = GlobalConfig {
+            enable_blob_redirect: Some(true),
+            enable_manifest_redirect: Some(false),
+            ..GlobalConfig::default()
+        };
+        assert!(config.resolved_enable_blob_redirect());
+        assert!(!config.resolved_enable_manifest_redirect());
+    }
+
+    #[test]
+    fn test_redirect_resolver_new_wins_over_old() {
+        let config = GlobalConfig {
+            enable_redirect: Some(false),
+            enable_blob_redirect: Some(true),
+            ..GlobalConfig::default()
+        };
+        assert!(config.resolved_enable_blob_redirect());
+        assert!(!config.resolved_enable_manifest_redirect());
+    }
+
+    #[test]
+    fn test_redirect_resolver_nothing_set_defaults_true() {
+        let config = GlobalConfig::default();
+        assert!(config.resolved_enable_blob_redirect());
+        assert!(config.resolved_enable_manifest_redirect());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,8 @@ async fn run_command(cli_args: GlobalArguments, config: Configuration) {
         std::process::exit(1);
     }
 
+    config.log_deprecations();
+
     match cli_args.subcommand {
         SubCommand::Argon(_) => {
             if let Err(err) = argon::Command::run() {

--- a/src/registry/blob.rs
+++ b/src/registry/blob.rs
@@ -299,7 +299,7 @@ impl Registry {
 
         if range.is_none()
             && self.enable_redirect
-            && let Ok(Some(presigned_url)) = self.blob_store.get_blob_url(digest).await
+            && let Ok(Some(presigned_url)) = self.blob_store.get_blob_url(digest, None).await
         {
             return Response::builder()
                 .status(StatusCode::TEMPORARY_REDIRECT)

--- a/src/registry/blob.rs
+++ b/src/registry/blob.rs
@@ -298,7 +298,7 @@ impl Registry {
         }
 
         if range.is_none()
-            && self.enable_redirect
+            && self.enable_blob_redirect
             && let Ok(Some(presigned_url)) = self.blob_store.get_blob_url(digest, None).await
         {
             return Response::builder()

--- a/src/registry/blob_store/fs/mod.rs
+++ b/src/registry/blob_store/fs/mod.rs
@@ -305,7 +305,7 @@ impl BlobStore for Backend {
     }
 
     #[instrument(skip(self))]
-    async fn get_blob_url(&self, _digest: &Digest) -> Result<Option<String>, Error> {
+    async fn get_blob_url(&self, _: &Digest, _: Option<&str>) -> Result<Option<String>, Error> {
         Ok(None)
     }
 

--- a/src/registry/blob_store/mod.rs
+++ b/src/registry/blob_store/mod.rs
@@ -93,7 +93,11 @@ pub trait BlobStore: Send + Sync {
         start_offset: Option<u64>,
     ) -> Result<(BoxedReader, u64), Error>;
 
-    async fn get_blob_url(&self, digest: &Digest) -> Result<Option<String>, Error>;
+    async fn get_blob_url(
+        &self,
+        digest: &Digest,
+        content_type: Option<&str>,
+    ) -> Result<Option<String>, Error>;
 
     async fn delete_blob(&self, digest: &Digest) -> Result<(), Error>;
 }

--- a/src/registry/blob_store/s3/mod.rs
+++ b/src/registry/blob_store/s3/mod.rs
@@ -918,11 +918,15 @@ impl BlobStore for Backend {
     }
 
     #[instrument(skip(self))]
-    async fn get_blob_url(&self, digest: &Digest) -> Result<Option<String>, Error> {
+    async fn get_blob_url(
+        &self,
+        digest: &Digest,
+        content_type: Option<&str>,
+    ) -> Result<Option<String>, Error> {
         let path = path_builder::blob_path(digest);
         let url = self
             .store
-            .generate_presigned_url(&path, std::time::Duration::from_secs(1800))
+            .generate_presigned_url(&path, std::time::Duration::from_secs(1800), content_type)
             .await?;
         Ok(Some(url))
     }

--- a/src/registry/data_store/s3.rs
+++ b/src/registry/data_store/s3.rs
@@ -951,14 +951,17 @@ impl Backend {
         &self,
         path: &str,
         expires_in: Duration,
+        response_content_type: Option<&str>,
     ) -> Result<String, IoError> {
         let key = self.full_key(path);
 
-        let presigned = self
-            .s3_client
-            .get_object()
-            .bucket(&self.bucket)
-            .key(&key)
+        let mut builder = self.s3_client.get_object().bucket(&self.bucket).key(&key);
+
+        if let Some(ct) = response_content_type {
+            builder = builder.response_content_type(ct);
+        }
+
+        let presigned = builder
             .presigned(
                 aws_sdk_s3::presigning::PresigningConfig::expires_in(expires_in)
                     .map_err(|e| IoError::other(e.to_string()))?,

--- a/src/registry/manifest.rs
+++ b/src/registry/manifest.rs
@@ -508,7 +508,10 @@ impl Registry {
                     .await
             }
             && let Some(media_type) = link.media_type
-            && let Ok(Some(presigned_url)) = self.blob_store.get_blob_url(&link.target).await
+            && let Ok(Some(presigned_url)) = self
+                .blob_store
+                .get_blob_url(&link.target, Some(media_type.as_str()))
+                .await
         {
             return Response::builder()
                 .status(StatusCode::TEMPORARY_REDIRECT)
@@ -533,7 +536,10 @@ impl Registry {
         // lacks media_type), fall back to reading the full blob via get_manifest then
         // redirecting. Remove this block once all links have been re-pushed.
         if self.enable_redirect
-            && let Ok(Some(presigned_url)) = self.blob_store.get_blob_url(&manifest.digest).await
+            && let Ok(Some(presigned_url)) = self
+                .blob_store
+                .get_blob_url(&manifest.digest, manifest.media_type.as_deref())
+                .await
         {
             let mut builder = Response::builder()
                 .status(StatusCode::TEMPORARY_REDIRECT)

--- a/src/registry/manifest.rs
+++ b/src/registry/manifest.rs
@@ -500,7 +500,7 @@ impl Registry {
     ) -> Result<Response<ResponseBody>, Error> {
         let repository = self.get_repository_for_namespace(namespace)?;
 
-        if self.enable_redirect
+        if self.enable_manifest_redirect
             && let Ok(link) = {
                 let blob_link: LinkKind = reference.clone().into();
                 self.metadata_store
@@ -535,7 +535,7 @@ impl Registry {
         // Backward compatibility: when the optimized redirect path above fails (link
         // lacks media_type), fall back to reading the full blob via get_manifest then
         // redirecting. Remove this block once all links have been re-pushed.
-        if self.enable_redirect
+        if self.enable_manifest_redirect
             && let Ok(Some(presigned_url)) = self
                 .blob_store
                 .get_blob_url(&manifest.digest, manifest.media_type.as_deref())

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -31,9 +31,11 @@ use crate::{
     registry::{blob_store::BlobStore, metadata_store::MetadataStore, task_queue::TaskQueue},
 };
 
+#[allow(clippy::struct_excessive_bools)]
 pub struct RegistryConfig {
     pub update_pull_time: bool,
-    pub enable_redirect: bool,
+    pub enable_blob_redirect: bool,
+    pub enable_manifest_redirect: bool,
     pub concurrent_cache_jobs: usize,
     pub global_immutable_tags: bool,
     pub global_immutable_tags_exclusions: Vec<String>,
@@ -43,7 +45,8 @@ impl Default for RegistryConfig {
     fn default() -> Self {
         Self {
             update_pull_time: false,
-            enable_redirect: true,
+            enable_blob_redirect: true,
+            enable_manifest_redirect: true,
             concurrent_cache_jobs: 4,
             global_immutable_tags: false,
             global_immutable_tags_exclusions: Vec::new(),
@@ -61,8 +64,13 @@ impl RegistryConfig {
         self
     }
 
-    pub fn enable_redirect(mut self, enabled: bool) -> Self {
-        self.enable_redirect = enabled;
+    pub fn enable_blob_redirect(mut self, enabled: bool) -> Self {
+        self.enable_blob_redirect = enabled;
+        self
+    }
+
+    pub fn enable_manifest_redirect(mut self, enabled: bool) -> Self {
+        self.enable_manifest_redirect = enabled;
         self
     }
 
@@ -82,11 +90,13 @@ impl RegistryConfig {
     }
 }
 
+#[allow(clippy::struct_excessive_bools)]
 pub struct Registry {
     blob_store: Arc<dyn BlobStore + Send + Sync>,
     metadata_store: Arc<dyn MetadataStore + Send + Sync>,
     repositories: Arc<HashMap<String, Repository>>,
-    enable_redirect: bool,
+    enable_blob_redirect: bool,
+    enable_manifest_redirect: bool,
     update_pull_time: bool,
     task_queue: TaskQueue,
     global_immutable_tags: bool,
@@ -109,7 +119,8 @@ impl Registry {
     ) -> Result<Self, Error> {
         let res = Self {
             update_pull_time: config.update_pull_time,
-            enable_redirect: config.enable_redirect,
+            enable_blob_redirect: config.enable_blob_redirect,
+            enable_manifest_redirect: config.enable_manifest_redirect,
             blob_store,
             metadata_store,
             repositories,
@@ -191,7 +202,8 @@ pub mod test_utils {
 
         let config = RegistryConfig::new()
             .update_pull_time(global.update_pull_time)
-            .enable_redirect(global.enable_redirect)
+            .enable_blob_redirect(global.resolved_enable_blob_redirect())
+            .enable_manifest_redirect(global.resolved_enable_manifest_redirect())
             .concurrent_cache_jobs(global.max_concurrent_cache_jobs)
             .global_immutable_tags(global.immutable_tags)
             .global_immutable_tags_exclusions(global.immutable_tags_exclusions.clone());


### PR DESCRIPTION
Podman and skopeo complains apparently because of wrong content-type being returned when using pre-signed S3 URLs.