### PR TITLE
Harden deployment securityContext and use more standard labels

### DIFF
--- a/contrib/kubernetes/kustomize/base/cronjob.yaml
+++ b/contrib/kubernetes/kustomize/base/cronjob.yaml
@@ -4,12 +4,17 @@ apiVersion: batch/v1
 metadata:
   name: scrub
   namespace: angos
+  labels:
+    app.kubernetes.io/name: angos-scrub
 spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: angos-scrub
         spec:
           restartPolicy: Never
           containers:

--- a/contrib/kubernetes/kustomize/base/deployment.yaml
+++ b/contrib/kubernetes/kustomize/base/deployment.yaml
@@ -5,16 +5,16 @@ metadata:
   name: angos
   namespace: angos
   labels:
-    app: angos
+    app.kubernetes.io/name: angos
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: angos
+      app.kubernetes.io/name: angos
   template:
     metadata:
       labels:
-        app: angos
+        app.kubernetes.io/name: angos
     spec:
       containers:
       - name: angos
@@ -45,10 +45,25 @@ spec:
             cpu: "100m"
           limits:
             memory: "500Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_BIND_SERVICE
         volumeMounts:
         - name: angos-config
           mountPath: /config.toml
           subPath: config.toml
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: angos-config
         secret:

--- a/contrib/kubernetes/kustomize/base/service.yaml
+++ b/contrib/kubernetes/kustomize/base/service.yaml
@@ -4,9 +4,11 @@ apiVersion: v1
 metadata:
   name: angos
   namespace: angos
+  labels:
+    app.kubernetes.io/name: angos
 spec:
   selector:
-    app: angos
+    app.kubernetes.io/name: angos
   ports:
   - protocol: TCP
     port: 8000

--- a/contrib/kubernetes/kustomize/base/valkey-deployment.yaml
+++ b/contrib/kubernetes/kustomize/base/valkey-deployment.yaml
@@ -21,3 +21,13 @@ spec:
         image: valkey/valkey:8.0.2
         ports:
         - containerPort: 6379
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          fsGroup: 1000
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true

--- a/contrib/kubernetes/kustomize/base/valkey-deployment.yaml
+++ b/contrib/kubernetes/kustomize/base/valkey-deployment.yaml
@@ -5,16 +5,16 @@ metadata:
   name: valkey-deployment
   namespace: angos
   labels:
-    app: valkey
+    app.kubernetes.io/name: valkey
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: valkey
+      app.kubernetes.io/name: valkey
   template:
     metadata:
       labels:
-        app: valkey
+        app.kubernetes.io/name: valkey
     spec:
       containers:
       - name: valkey

--- a/contrib/kubernetes/kustomize/base/valkey-service.yaml
+++ b/contrib/kubernetes/kustomize/base/valkey-service.yaml
@@ -5,10 +5,10 @@ metadata:
   name: valkey
   namespace: angos
   labels:
-    app: valkey
+    app.kubernetes.io/name: valkey
 spec:
   selector:
-    app: valkey
+    app.kubernetes.io/name: valkey
   ports:
     - protocol: TCP
       port: 6379


### PR DESCRIPTION
* Use standardized Kubernetes prefixed labels
* Add missing securityContexts
