### PR TITLE
fix: inverted securityContext in valkey contrib/kubernetes

### DIFF
--- a/contrib/kubernetes/kustomize/base/valkey-deployment.yaml
+++ b/contrib/kubernetes/kustomize/base/valkey-deployment.yaml
@@ -22,12 +22,13 @@ spec:
         ports:
         - containerPort: 6379
         securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
-          fsGroup: 1000
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+        


### PR DESCRIPTION
i accidentaly inverted pod.securityContext and container.securityContext in previous hardening PR #83 