### PR TITLE
Cancel selected uploads in bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## 1.3.1
 
+### Added
+
+- The web UI upload list has per-row checkboxes and a select-all toggle, so many in-progress uploads can be cancelled in one action.
+
 ## Changed
 
 - Storage coordination now runs entirely on the metadata store: the blob store holds only blob bytes (its backend no longer carries `.tx-log/`/`.tx-bodies/` prefixes) and the in-process job queue persists on the metadata store.

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -224,6 +224,19 @@ h3 {
 	gap: 0.5rem;
 }
 
+/* Delete controls in a card header stay as compact as their table
+   counterparts so their appearance does not change the header height. */
+.header-actions button.danger,
+.header-actions .delete-confirm button {
+	padding: 0.2rem 0.5rem;
+	font-size: 0.6875rem;
+	line-height: 1;
+}
+
+.header-actions > button.danger {
+	border-radius: 3px;
+}
+
 /* ===== TABLES ===== */
 table {
 	width: 100%;
@@ -922,6 +935,10 @@ a:hover {
 
 .col-actions {
 	width: 140px;
+}
+
+.col-select {
+	width: 36px;
 }
 
 /* ===== SCROLLBAR ===== */

--- a/ui/src/lib/components/RepositoryTree.svelte
+++ b/ui/src/lib/components/RepositoryTree.svelte
@@ -6,6 +6,7 @@
 		formatTimeAgo,
 		isInteractiveTarget,
 		manifestUrl,
+		selectedUploadsConfirmKey,
 		uploadConfirmKey,
 		type TreeRowNode
 	} from '$lib/utils';
@@ -18,6 +19,7 @@
 		namespace: string;
 		rows: TreeRowNode[];
 		uploads: UploadEntry[];
+		selectedUploads: Set<string>;
 		deleteConfirm: string | null;
 		deleting: boolean;
 		expanded: Set<string>;
@@ -26,6 +28,8 @@
 		ondeletemanifest: (digest: string) => void;
 		ondeletetag: (tag: string) => void;
 		oncancelupload: (uuid: string) => void;
+		onuploadselectionchange: (selected: Set<string>) => void;
+		oncancelselecteduploads: () => void;
 	}
 
 	let {
@@ -33,6 +37,7 @@
 		namespace,
 		rows,
 		uploads,
+		selectedUploads,
 		deleteConfirm,
 		deleting,
 		expanded,
@@ -40,8 +45,30 @@
 		onconfirmchange,
 		ondeletemanifest,
 		ondeletetag,
-		oncancelupload
+		oncancelupload,
+		onuploadselectionchange,
+		oncancelselecteduploads
 	}: Props = $props();
+
+	const allUploadsSelected = $derived(
+		uploads.length > 0 && uploads.every((upload) => selectedUploads.has(upload.uuid))
+	);
+
+	function toggleUploadSelection(uuid: string) {
+		const selected = new Set(selectedUploads);
+		if (selected.has(uuid)) {
+			selected.delete(uuid);
+		} else {
+			selected.add(uuid);
+		}
+		onuploadselectionchange(selected);
+	}
+
+	function toggleAllUploads() {
+		onuploadselectionchange(
+			allUploadsSelected ? new Set() : new Set(uploads.map((upload) => upload.uuid))
+		);
+	}
 
 	function handleRowClick(event: MouseEvent, targetDigest: string) {
 		if (isInteractiveTarget(event)) return;
@@ -51,9 +78,30 @@
 
 {#if uploads.length > 0}
 	<Card title="Uploads in progress" count={uploads.length} variant="warning">
+		{#snippet headerActions()}
+			{#if selectedUploads.size > 0}
+				<DeleteButton
+					label={`cancel selected (${selectedUploads.size})`}
+					isConfirming={deleteConfirm === selectedUploadsConfirmKey}
+					disabled={deleting}
+					onconfirm={oncancelselecteduploads}
+					oncancel={() => onconfirmchange(null)}
+					onrequestconfirm={() => onconfirmchange(selectedUploadsConfirmKey)}
+				/>
+			{/if}
+		{/snippet}
 		<table>
 			<thead>
 				<tr>
+					<th class="col-select">
+						<input
+							type="checkbox"
+							aria-label="Select all uploads"
+							checked={allUploadsSelected}
+							disabled={deleting}
+							onchange={toggleAllUploads}
+						/>
+					</th>
 					<th>UUID</th>
 					<th>Size</th>
 					<th>Started</th>
@@ -63,6 +111,15 @@
 			<tbody>
 				{#each uploads as upload}
 					<tr>
+						<td class="col-select">
+							<input
+								type="checkbox"
+								aria-label={`Select upload ${upload.uuid}`}
+								checked={selectedUploads.has(upload.uuid)}
+								disabled={deleting}
+								onchange={() => toggleUploadSelection(upload.uuid)}
+							/>
+						</td>
 						<td><code class="uuid">{upload.uuid}</code></td>
 						<td>{formatSize(upload.size)}</td>
 						<td>{formatTimeAgo(upload.started_at)}</td>

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -168,6 +168,8 @@ export function uploadConfirmKey(uuid: string): string {
 	return `upload:${uuid}`;
 }
 
+export const selectedUploadsConfirmKey = 'uploads:selected';
+
 const WELL_KNOWN_ANNOTATIONS: Record<string, string> = {
 	'org.opencontainers.image.created': 'created',
 	'org.opencontainers.image.authors': 'authors',

--- a/ui/src/routes/[repository]/[...path]/+page.svelte
+++ b/ui/src/routes/[repository]/[...path]/+page.svelte
@@ -17,6 +17,7 @@
 
 	let rows: TreeRowNode[] = $state([]);
 	let uploads: UploadEntry[] = $state([]);
+	let selectedUploads: Set<string> = $state(new Set());
 
 	let manifest: Manifest | null = $state(null);
 	let digest: string | null = $state(null);
@@ -66,6 +67,7 @@
 		} else {
 			uploads = [];
 		}
+		selectedUploads = new Set();
 		loading = false;
 	}
 
@@ -166,6 +168,22 @@
 		deleting = false;
 	}
 
+	async function cancelSelectedUploads() {
+		deleting = true;
+		error = null;
+		const uuids = [...selectedUploads];
+		const results = await Promise.all(
+			uuids.map((uuid) => apiCancelUpload(fullNamespace, uuid))
+		);
+		deleteConfirm = null;
+		await loadNamespace(fullNamespace);
+		const failed = results.filter((err) => err !== null).length;
+		if (failed > 0) {
+			error = `Failed to cancel ${failed} of ${uuids.length} uploads`;
+		}
+		deleting = false;
+	}
+
 	async function downloadBlob(blobDigest: string, filename: string | null) {
 		const err = await apiDownloadBlob(fullNamespace, blobDigest, filename);
 		if (err) {
@@ -223,6 +241,7 @@
 		namespace={data.namespace}
 		{rows}
 		{uploads}
+		{selectedUploads}
 		{deleteConfirm}
 		{deleting}
 		{expanded}
@@ -231,5 +250,7 @@
 		ondeletemanifest={deleteManifestByRef}
 		ondeletetag={deleteTag}
 		oncancelupload={cancelUpload}
+		onuploadselectionchange={(selected) => selectedUploads = selected}
+		oncancelselecteduploads={cancelSelectedUploads}
 	/>
 {/if}


### PR DESCRIPTION
Solves https://github.com/project-angos/angos/issues/160

The logic is fully client side.

Multi select:
<img width="1460" height="655" alt="before" src="https://github.com/user-attachments/assets/1ea51537-7d36-4e71-9d25-3accb2e4c08c" />

After deletion:
<img width="1460" height="655" alt="after" src="https://github.com/user-attachments/assets/d5f6ea4d-13a8-41bb-a8eb-16a673687515" />
